### PR TITLE
Update rules for Sweden Recycling to use correct quotes

### DIFF
--- a/src/maps/sweden/rules.tsx
+++ b/src/maps/sweden/rules.tsx
@@ -8,7 +8,7 @@ export function SwedenRules() {
         </li>
         <li>
           <b>Goods growth is skipped:</b> Instead, at the end of the move phase,
-          all delivered goods are &qt;recycled&qt;.
+          all delivered goods are &quot;recycled&quot;.
         </li>
         <li>
           <b>Recycling:</b> Yellow cubes -&gt; red -&gt; blue -&gt; black. After


### PR DESCRIPTION
The rules for Sweden Recycling used &qt instead of the correct &quote html entity