### PR TITLE
Fix initial cube placement for St. Lucia

### DIFF
--- a/src/maps/st-lucia/starter.ts
+++ b/src/maps/st-lucia/starter.ts
@@ -9,7 +9,9 @@ export class StLuciaStarter extends GameStarter {
   }
 
   protected drawCubesFor(bag: Good[], location: SpaceData): SpaceData {
-    if (location.type === SpaceType.CITY || location.townName != null) {
+    if (location.type === SpaceType.CITY || 
+        location.townName != null ||
+        location.type === SpaceType.MOUNTAIN) {
       return location;
     }
     return {


### PR DESCRIPTION
As per rules: 

> _**Setup**
> Randomly place 1 cube on each plain green hex and each river hex on the board._

Raised by tropicalpenguin on 30.04.2025.