### PR TITLE
Detroit Engineer Fix

### DIFF
--- a/src/maps/detroit/engineer.ts
+++ b/src/maps/detroit/engineer.ts
@@ -57,7 +57,7 @@ class FreeBuildManager {
       return { newCost: currentCost };
     }
     return {
-      newCost: this.freeBuild() - currentCost,
+      newCost: this.freeBuild(),
       newCheapestBuild: currentCost,
     };
   }


### PR DESCRIPTION
No idea why the deduction in _newCost_ was even introduced. 

It resulted in weird scenarios - when a player would first claim any >$2 track/link the entire Engineer build would discount that one link or would result in deduction of $4 if you first took $10 and then $6 link etc.