### PR TITLE
Log when specifically which good are added to cities during goods growth

### DIFF
--- a/src/engine/goods_growth/helper.ts
+++ b/src/engine/goods_growth/helper.ts
@@ -6,13 +6,15 @@ import { Random } from "../game/random";
 import { BAG } from "../game/state";
 import { City } from "../map/city";
 import { GridHelper } from "../map/grid_helper";
-import { Good } from "../state/good";
+import { Good, goodToString } from "../state/good";
 import { SpaceType } from "../state/location_type";
+import { Log } from "../game/log";
 
 export class GoodsHelper {
   protected readonly bag = injectState(BAG);
   protected readonly random = inject(Random);
   protected readonly grid = inject(GridHelper);
+  protected readonly log = inject(Log);
 
   getTotalUpcomingGoodsSlots(urbanized: boolean) {
     return urbanized ? 2 : 3;
@@ -57,7 +59,12 @@ export class GoodsHelper {
         }
         newGoods.push(newGood);
       }
-      location.goods.push(...newGoods);
+      for (const good of newGoods) {
+        this.log.log(
+          `A ${goodToString(good)} good is added to ${this.grid.displayName(coordinates)}`,
+        );
+        location.goods.push(good);
+      }
     });
   }
 

--- a/src/engine/map/grid_helper.ts
+++ b/src/engine/map/grid_helper.ts
@@ -76,6 +76,10 @@ export class GridHelper {
     return this.spaces().values();
   }
 
+  displayName(coordinates: Coordinates): string {
+    return this.spaces().displayName(coordinates);
+  }
+
   *findAllCities(): Iterable<City> {
     for (const space of this.all()) {
       if (space instanceof City) yield space;


### PR DESCRIPTION
Just played a live game and we all had a bit of a hard time following what happened during goods growth because although the dice numbers that are rolled are logged, we weren't sure whether the corresponding columns of the goods growth chart were already empty or not.