### PR TITLE
Make game cards 100% width on mobile

### DIFF
--- a/src/client/home/game_list.tsx
+++ b/src/client/home/game_list.tsx
@@ -48,7 +48,7 @@ export function GameList({
     <div className={styles.gameListCard}>
       <h2>{title}</h2>
 
-      <CardGroup>
+      <CardGroup stackable>
         {gamesInOrder.map((game) => (
           <GameCard game={game} key={game.id} hideStatus={hideStatus} />
         ))}


### PR DESCRIPTION
Apparently "stackable" was the magic missing prop to get this behavior.