### PR TITLE
Semantic UI updates for active game page

### DIFF
--- a/src/client/auto_action/form.module.css
+++ b/src/client/auto_action/form.module.css
@@ -3,6 +3,10 @@
   flex-direction: column;
 }
 
+.subForm {
+  margin-left: 2em;
+}
+
 div.tab {
   margin-left: 42px;
 }

--- a/src/client/auto_action/form.tsx
+++ b/src/client/auto_action/form.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useCallback, useState} from "react";
+import { MouseEvent, useCallback, useState } from "react";
 import { GameStatus } from "../../api/game";
 import { inject } from "../../engine/framework/execution_context";
 import { AllowedActions } from "../../engine/select_action/allowed_actions";
@@ -18,7 +18,8 @@ import {
   Accordion,
   AccordionContent,
   AccordionTitle,
-  Form, FormCheckbox,
+  Form,
+  FormCheckbox,
   FormField,
   FormGroup,
   Menu,
@@ -27,8 +28,8 @@ import {
   Icon,
   Input,
   Button,
-  Radio, Dropdown,
-    Label
+  Radio,
+  Dropdown,
 } from "semantic-ui-react";
 
 export function AutoActionForm() {
@@ -74,21 +75,23 @@ function InternalAutoActionForm({
     () => inject(AllowedActions).getActions(),
     [],
   );
-  const [skipShares, setSkipShares] = useSemanticUiCheckboxState(autoAction.skipShares);
-  const [takeSharesNextDefined, setTakeSharesNextDefined] = useSemanticUiCheckboxState(
-    autoAction.takeSharesNext != null,
+  const [skipShares, setSkipShares] = useSemanticUiCheckboxState(
+    autoAction.skipShares,
   );
+  const [takeSharesNextDefined, setTakeSharesNextDefined] =
+    useSemanticUiCheckboxState(autoAction.takeSharesNext != null);
   const [takeSharesNext, setTakeSharesNext] = useNumberInputState(
     autoAction.takeSharesNext ?? "",
   );
-  const [takeActionNextDefined, setTakeActionNextDefined] = useSemanticUiCheckboxState(
-    autoAction.takeActionNext != null,
-  );
+  const [takeActionNextDefined, setTakeActionNextDefined] =
+    useSemanticUiCheckboxState(autoAction.takeActionNext != null);
   const [takeActionNext, setTakeActionNext] = useSemanticSelectState<Action>(
     autoAction.takeActionNext ??
       availableActions[Symbol.iterator]().next().value,
   );
-  const [locoNext, setLocoNext] = useSemanticUiCheckboxState(autoAction.locoNext);
+  const [locoNext, setLocoNext] = useSemanticUiCheckboxState(
+    autoAction.locoNext,
+  );
   const [bidUntilDefined, setBidUntilDefined] = useSemanticUiCheckboxState(
     autoAction.bidUntil != null,
   );
@@ -155,7 +158,12 @@ function InternalAutoActionForm({
   return (
     <Accordion fluid as={Menu} vertical>
       <MenuItem>
-        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content={"Auto Actions" + (count > 0 ? ` (${count})` : "")} />
+        <AccordionTitle
+          active={expanded}
+          index={0}
+          onClick={() => setExpanded(!expanded)}
+          content={"Auto Actions" + (count > 0 ? ` (${count})` : "")}
+        />
         <AccordionContent active={expanded}>
           <Form>
             <FormCheckbox
@@ -163,60 +171,65 @@ function InternalAutoActionForm({
               disabled={isPending}
               onChange={setSkipShares}
               error={validationError?.skipShares}
-              label={<label>
-                Done taking shares.
-                {' '}<Popup
-                    trigger={<Icon circular size="small" name='question' />}
+              label={
+                <label>
+                  Done taking shares.{" "}
+                  <Popup
+                    trigger={<Icon circular size="small" name="question" />}
                     content="Every time it's your turn to take out shares,
                       you'll pass without taking any shares. This will
                       continue until the game ends or you untoggle this button."
-                />
-              </label>}
+                  />
+                </label>
+              }
             />
 
             <FormCheckbox
-                checked={takeSharesNextDefined}
-                disabled={isPending}
-                onChange={setTakeSharesNextDefined}
-                error={validationError?.takeSharesNextDefined}
-                label={<label>
-                  Select how many shares to take out next shares round.
-                  {' '}<Popup
-                    trigger={<Icon circular size="small" name='question' />}
+              checked={takeSharesNextDefined}
+              disabled={isPending}
+              onChange={setTakeSharesNextDefined}
+              error={validationError?.takeSharesNextDefined}
+              label={
+                <label>
+                  Select how many shares to take out next shares round.{" "}
+                  <Popup
+                    trigger={<Icon circular size="small" name="question" />}
                     content="The next time it's your turn to take out shares,
                     you'll take out this many shares. This field gets reset
                     after the action is performed."
-                />
-                </label>}
+                  />
+                </label>
+              }
             />
 
             {takeSharesNextDefined && (
-                <div className={styles.subForm}>
-                  <FormGroup inline>
-                    <FormField
-                      label="Number of shares"
-                      control={Input}
-                      type="number"
-                      disabled={isPending}
-                      value={takeSharesNext}
-                      error={validationError?.takeSharesNext}
-                      onChange={setTakeSharesNext}
-                      />
-                  </FormGroup>
-                </div>
+              <div className={styles.subForm}>
+                <FormGroup inline>
+                  <FormField
+                    label="Number of shares"
+                    control={Input}
+                    type="number"
+                    disabled={isPending}
+                    value={takeSharesNext}
+                    error={validationError?.takeSharesNext}
+                    onChange={setTakeSharesNext}
+                  />
+                </FormGroup>
+              </div>
             )}
 
             <FormCheckbox
-                checked={bidUntilDefined}
-                disabled={isPending}
-                onChange={setBidUntilDefined}
-                error={validationError?.bidUntilDefined}
-                label="Auto-bidding"
+              checked={bidUntilDefined}
+              disabled={isPending}
+              onChange={setBidUntilDefined}
+              error={validationError?.bidUntilDefined}
+              label="Auto-bidding"
             />
 
-            {bidUntilDefined && <div className={styles.subForm}>
-              <FormGroup inline>
-                <FormField
+            {bidUntilDefined && (
+              <div className={styles.subForm}>
+                <FormGroup inline>
+                  <FormField
                     label="Max bid"
                     control={Input}
                     type="number"
@@ -224,91 +237,110 @@ function InternalAutoActionForm({
                     value={maxBid}
                     error={validationError?.["bidUntil.maxBid"]}
                     onChange={setMaxBid}
-                />
-              </FormGroup>
-              <FormGroup grouped>
-                <FormField>
-                  <Radio
-                    label="Incrementally +1 previous bid until max bid is reached"
-                    checked={incrementally}
-                    onChange={() => handleIncrementallyChange(true)}
-                    disabled={isPending} />
-                </FormField>
-                <FormField>
-                  <Radio
-                    label="Jump right to max bid"
-                    checked={!incrementally}
-                    onChange={() => handleIncrementallyChange(false)}
-                    disabled={isPending} />
-                </FormField>
-              </FormGroup>
-              <FormGroup>
-                <FormCheckbox
+                  />
+                </FormGroup>
+                <FormGroup grouped>
+                  <FormField>
+                    <Radio
+                      label="Incrementally +1 previous bid until max bid is reached"
+                      checked={incrementally}
+                      onChange={() => handleIncrementallyChange(true)}
+                      disabled={isPending}
+                    />
+                  </FormField>
+                  <FormField>
+                    <Radio
+                      label="Jump right to max bid"
+                      checked={!incrementally}
+                      onChange={() => handleIncrementallyChange(false)}
+                      disabled={isPending}
+                    />
+                  </FormField>
+                </FormGroup>
+                <FormGroup>
+                  <FormCheckbox
                     checked={thenPass}
                     disabled={isPending}
                     onChange={setThenPass}
                     error={validationError?.["bidUntil.thenPass"]}
-                    label={<label>
-                      Pass once max bid is exceeded
-                      {' '}<Popup
-                        trigger={<Icon circular size="small" name='question' />}
-                        content="The next time it's your turn to bid and the bid is
+                    label={
+                      <label>
+                        Pass once max bid is exceeded{" "}
+                        <Popup
+                          trigger={
+                            <Icon circular size="small" name="question" />
+                          }
+                          content="The next time it's your turn to bid and the bid is
                           greater than your max, you'll pass instead. Leave
                           blank if you want to bid until the max bid, then decide
                           what to do."
-                      />
-                    </label>}
-                />
-              </FormGroup>
-            </div>}
+                        />
+                      </label>
+                    }
+                  />
+                </FormGroup>
+              </div>
+            )}
 
             <FormCheckbox
-                checked={takeActionNextDefined}
-                disabled={isPending}
-                onChange={setTakeActionNextDefined}
-                error={validationError?.takeActionNextDefined}
-                label={<label>
-                  Select an action (if available).
-                  {' '}<Popup
-                    trigger={<Icon circular size="small" name='question' />}
+              checked={takeActionNextDefined}
+              disabled={isPending}
+              onChange={setTakeActionNextDefined}
+              error={validationError?.takeActionNextDefined}
+              label={
+                <label>
+                  Select an action (if available).{" "}
+                  <Popup
+                    trigger={<Icon circular size="small" name="question" />}
                     content=" The next time it's your turn to select an action,
                       it'll select this action if it's available.
                       Otherwise, it'll just wait for you to select an action.
                       Resets after an action is selected."
                   />
-                </label>}
+                </label>
+              }
             />
 
-            {takeActionNextDefined && <div className={styles.subForm}>
-              <FormGroup widths="equal">
-                <FormField error={validationError?.takeActionNext} required>
-                  <label>Selected Action</label>
-                  <Dropdown
-                    fluid
-                    selection
-                    value={takeActionNext}
-                    onChange={setTakeActionNext}
-                    disabled={isPending}
-                    options={[...availableActions].map((action) => {
-                      return {
-                        key: action,
-                        value: action,
-                        text: getSelectedActionString(action),
-                      };
-                    })} />
-                </FormField>
-              </FormGroup>
-            </div>}
+            {takeActionNextDefined && (
+              <div className={styles.subForm}>
+                <FormGroup widths="equal">
+                  <FormField error={validationError?.takeActionNext} required>
+                    <label>Selected Action</label>
+                    <Dropdown
+                      fluid
+                      selection
+                      value={takeActionNext}
+                      onChange={setTakeActionNext}
+                      disabled={isPending}
+                      options={[...availableActions].map((action) => {
+                        return {
+                          key: action,
+                          value: action,
+                          text: getSelectedActionString(action),
+                        };
+                      })}
+                    />
+                  </FormField>
+                </FormGroup>
+              </div>
+            )}
 
             <FormCheckbox
-                checked={locoNext}
-                disabled={isPending}
-                onChange={setLocoNext}
-                error={validationError?.locoNext}
-                label="Loco as your next Move Goods action"
+              checked={locoNext}
+              disabled={isPending}
+              onChange={setLocoNext}
+              error={validationError?.locoNext}
+              label="Loco as your next Move Goods action"
             />
 
-            <Button primary type="submit" disabled={isPending} onClick={onSubmit}>Submit</Button>
+            <Button
+              primary
+              type="submit"
+              disabled={isPending}
+              onClick={onSubmit}
+            >
+              Submit
+            </Button>
           </Form>
         </AccordionContent>
       </MenuItem>

--- a/src/client/game/active_game.tsx
+++ b/src/client/game/active_game.tsx
@@ -67,11 +67,11 @@ function InternalActiveGame() {
         <SwitchToActive />
         <SwitchToUndo />
         {!undoOnly && <ActionSummary />}
+        {!undoOnly && canEmitProduction && <GoodsTable />}
+        {!undoOnly && <BiddingInfo />}
+        {!undoOnly && canEmitSelectAction && <SpecialActionTable />}
         <AutoActionForm />
       </Segment>
-      {!undoOnly && canEmitProduction && <GoodsTable />}
-      {!undoOnly && <BiddingInfo />}
-      {!undoOnly && canEmitSelectAction && <SpecialActionTable />}
       <RetryButton />
       {!undoOnly && <PlayerStats />}
       <IncomeTrack />

--- a/src/client/game/active_game.tsx
+++ b/src/client/game/active_game.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@mui/material";
 import { useSearchParams } from "react-router-dom";
 import { GameStatus } from "../../api/game";
 import { injectPlayersByTurnOrder } from "../../engine/game/state";
@@ -34,6 +33,7 @@ import { PlayerStats } from "./player_stats";
 import { SpecialActionTable } from "./special_action_table";
 import { SwitchToActive, SwitchToUndo } from "./switch";
 import { TileManifest } from "./tile_manifest";
+import {Button, Icon, Header, Segment} from "semantic-ui-react";
 
 export function ActiveGame() {
   const game = useGame();
@@ -56,17 +56,19 @@ function InternalActiveGame() {
 
   return (
     <div>
-      {!undoOnly && <Header />}
+      {!undoOnly && <GameHeader />}
       <GameLog />
       <HistorySelector />
-      <TurnOrder />
-      <Editor />
-      <UndoButton />
-      <DeleteButton game={game} />
-      <SwitchToActive />
-      <SwitchToUndo />
-      {!undoOnly && <ActionSummary />}
-      <AutoActionForm />
+      <Segment>
+        <TurnOrder />
+        <Editor />
+        <UndoButton />
+        <DeleteButton game={game} />
+        <SwitchToActive />
+        <SwitchToUndo />
+        {!undoOnly && <ActionSummary />}
+        <AutoActionForm />
+      </Segment>
       {!undoOnly && canEmitProduction && <GoodsTable />}
       {!undoOnly && <BiddingInfo />}
       {!undoOnly && canEmitSelectAction && <SpecialActionTable />}
@@ -112,7 +114,7 @@ function TurnOrder() {
   );
 }
 
-function Header() {
+function GameHeader() {
   const game = useGame();
   return (
     <h1 className={styles.header}>
@@ -128,7 +130,8 @@ function UndoButton() {
     return <></>;
   }
   return (
-    <Button onClick={undo} disabled={isPending}>
+    <Button icon labelPosition="left" basic negative onClick={undo} disabled={isPending}>
+      <Icon name="undo" />
       Undo
     </Button>
   );
@@ -140,7 +143,7 @@ function RetryButton() {
     return <></>;
   }
   return (
-    <Button onClick={retry} disabled={isPending}>
+    <Button basic color="teal" onClick={retry} disabled={isPending}>
       Retry
     </Button>
   );

--- a/src/client/game/active_game.tsx
+++ b/src/client/game/active_game.tsx
@@ -33,7 +33,7 @@ import { PlayerStats } from "./player_stats";
 import { SpecialActionTable } from "./special_action_table";
 import { SwitchToActive, SwitchToUndo } from "./switch";
 import { TileManifest } from "./tile_manifest";
-import {Button, Icon, Header, Segment} from "semantic-ui-react";
+import { Button, Icon, Segment } from "semantic-ui-react";
 
 export function ActiveGame() {
   const game = useGame();
@@ -130,7 +130,14 @@ function UndoButton() {
     return <></>;
   }
   return (
-    <Button icon labelPosition="left" basic negative onClick={undo} disabled={isPending}>
+    <Button
+      icon
+      labelPosition="left"
+      basic
+      negative
+      onClick={undo}
+      disabled={isPending}
+    >
       <Icon name="undo" />
       Undo
     </Button>

--- a/src/client/game/bidding_info.module.css
+++ b/src/client/game/bidding_info.module.css
@@ -1,4 +1,5 @@
 .colorListContainer {
+  margin-top: 1em;
   display: flex;
   flex-direction: column;
 }

--- a/src/client/game/editor.tsx
+++ b/src/client/game/editor.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, useCallback, useMemo, useState } from "react";
 import { useConfirm } from "../components/confirm";
 import { canEditGame, useGame, useSetGameData } from "../services/game";
 import { useIsAdmin } from "../services/me";
-import {Button, Icon} from "semantic-ui-react";
+import { Button, Icon } from "semantic-ui-react";
 
 export function Editor() {
   const isAdmin = useIsAdmin();
@@ -47,9 +47,17 @@ export function Editor() {
 
   return (
     <>
-      {isOpen ?
-          <Button icon labelPosition="left" basic color="blue" onClick={toggle}><Icon name="close"/>Close editor</Button> :
-          <Button icon labelPosition="left" basic color="blue" onClick={toggle}><Icon name="code"/>View Data</Button>}
+      {isOpen ? (
+        <Button icon labelPosition="left" basic color="blue" onClick={toggle}>
+          <Icon name="close" />
+          Close editor
+        </Button>
+      ) : (
+        <Button icon labelPosition="left" basic color="blue" onClick={toggle}>
+          <Icon name="code" />
+          View Data
+        </Button>
+      )}
 
       {isOpen && (
         <textarea

--- a/src/client/game/editor.tsx
+++ b/src/client/game/editor.tsx
@@ -1,8 +1,8 @@
-import { Button } from "@mui/material";
 import { ChangeEvent, useCallback, useMemo, useState } from "react";
 import { useConfirm } from "../components/confirm";
 import { canEditGame, useGame, useSetGameData } from "../services/game";
 import { useIsAdmin } from "../services/me";
+import {Button, Icon} from "semantic-ui-react";
 
 export function Editor() {
   const isAdmin = useIsAdmin();
@@ -47,7 +47,9 @@ export function Editor() {
 
   return (
     <>
-      <Button onClick={toggle}>{isOpen ? "Close editor" : "View Data"}</Button>
+      {isOpen ?
+          <Button icon labelPosition="left" basic color="blue" onClick={toggle}><Icon name="close"/>Close editor</Button> :
+          <Button icon labelPosition="left" basic color="blue" onClick={toggle}><Icon name="code"/>View Data</Button>}
 
       {isOpen && (
         <textarea

--- a/src/client/game/income_track.tsx
+++ b/src/client/game/income_track.tsx
@@ -1,20 +1,16 @@
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Typography,
-} from "@mui/material";
+
 import { times } from "lodash";
-import { useMemo } from "react";
+import {useMemo, useState} from "react";
 import { injectInGamePlayers } from "../../engine/game/state";
 import { partition, peek } from "../../utils/functions";
 import { useInject } from "../utils/injection_context";
 import { PlayerCircle } from "./bidding_info";
 import * as styles from "./income_track.module.css";
+import {Accordion, AccordionContent, AccordionTitle, Menu, MenuItem} from "semantic-ui-react";
 
 export function IncomeTrack() {
   const playerData = useInject(() => injectInGamePlayers()(), []);
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   const track = useMemo(() => {
     const maxIncome = Math.max(...playerData.map((player) => player.income));
@@ -30,32 +26,32 @@ export function IncomeTrack() {
   }, [playerData]);
 
   return (
-    <Accordion>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Typography component="h2">Income Track</Typography>
-      </AccordionSummary>
-      <AccordionDetails>
-        <div className={styles.container}>
-          {track.map((row, index) => (
-            <div key={index} className={styles.row}>
-              <div className={[styles.decrease, styles.cell].join(" ")}>
-                {index * -2}
-              </div>
-              {index !== 0 && <div className={styles.cell} />}
-              {row.map(({ value, players }) => (
-                <div key={value} className={styles.cell}>
-                  {players.slice(0, -1).map(({ color }) => (
-                    <PlayerCircle key={color} color={color} />
-                  ))}
-                  <PlayerCircle color={peek(players)?.color}>
-                    {value}
-                  </PlayerCircle>
+    <Accordion as={Menu} vertical fluid>
+      <MenuItem>
+        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Income Track" />
+        <AccordionContent active={expanded}>
+          <div className={styles.container}>
+            {track.map((row, index) => (
+              <div key={index} className={styles.row}>
+                <div className={[styles.decrease, styles.cell].join(" ")}>
+                  {index * -2}
                 </div>
-              ))}
-            </div>
-          ))}
-        </div>
-      </AccordionDetails>
+                {index !== 0 && <div className={styles.cell} />}
+                {row.map(({ value, players }) => (
+                  <div key={value} className={styles.cell}>
+                    {players.slice(0, -1).map(({ color }) => (
+                      <PlayerCircle key={color} color={color} />
+                    ))}
+                    <PlayerCircle color={peek(players)?.color}>
+                      {value}
+                    </PlayerCircle>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </AccordionContent>
+      </MenuItem>
     </Accordion>
   );
 }

--- a/src/client/game/income_track.tsx
+++ b/src/client/game/income_track.tsx
@@ -1,12 +1,17 @@
-
 import { times } from "lodash";
-import {useMemo, useState} from "react";
+import { useMemo, useState } from "react";
 import { injectInGamePlayers } from "../../engine/game/state";
 import { partition, peek } from "../../utils/functions";
 import { useInject } from "../utils/injection_context";
 import { PlayerCircle } from "./bidding_info";
 import * as styles from "./income_track.module.css";
-import {Accordion, AccordionContent, AccordionTitle, Menu, MenuItem} from "semantic-ui-react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionTitle,
+  Menu,
+  MenuItem,
+} from "semantic-ui-react";
 
 export function IncomeTrack() {
   const playerData = useInject(() => injectInGamePlayers()(), []);
@@ -28,7 +33,12 @@ export function IncomeTrack() {
   return (
     <Accordion as={Menu} vertical fluid>
       <MenuItem>
-        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Income Track" />
+        <AccordionTitle
+          active={expanded}
+          index={0}
+          onClick={() => setExpanded(!expanded)}
+          content="Income Track"
+        />
         <AccordionContent active={expanded}>
           <div className={styles.container}>
             {track.map((row, index) => (

--- a/src/client/game/login_button.tsx
+++ b/src/client/game/login_button.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@mui/material";
 import { ReactNode } from "react";
 import { useLoginBypass } from "../services/me";
+import {Button, Icon} from "semantic-ui-react";
 
 export function LoginButton({
   playerId,
@@ -13,7 +13,8 @@ export function LoginButton({
   if (!canUseLoginBypass) return <></>;
 
   return (
-    <Button onClick={login} disabled={isPending}>
+    <Button icon labelPosition="left" basic color="violet" onClick={login} disabled={isPending}>
+      <Icon name="user" />
       {children}
     </Button>
   );

--- a/src/client/game/login_button.tsx
+++ b/src/client/game/login_button.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { useLoginBypass } from "../services/me";
-import {Button, Icon} from "semantic-ui-react";
+import { Button, Icon } from "semantic-ui-react";
 
 export function LoginButton({
   playerId,
@@ -13,7 +13,14 @@ export function LoginButton({
   if (!canUseLoginBypass) return <></>;
 
   return (
-    <Button icon labelPosition="left" basic color="violet" onClick={login} disabled={isPending}>
+    <Button
+      icon
+      labelPosition="left"
+      basic
+      color="violet"
+      onClick={login}
+      disabled={isPending}
+    >
       <Icon name="user" />
       {children}
     </Button>

--- a/src/client/game/move_calculator.tsx
+++ b/src/client/game/move_calculator.tsx
@@ -1,5 +1,12 @@
-import {useCallback, useEffect, useState} from "react";
-import {Accordion, AccordionContent, AccordionTitle, Button, Menu, MenuItem} from "semantic-ui-react";
+import { useCallback, useState } from "react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionTitle,
+  Button,
+  Menu,
+  MenuItem,
+} from "semantic-ui-react";
 import { MoveAction, MoveData } from "../../engine/move/move";
 import { MoveSearcher } from "../../engine/move/searcher";
 import { goodToString } from "../../engine/state/good";
@@ -64,19 +71,33 @@ export function MoveCalculator() {
   return (
     <Accordion as={Menu} vertical fluid>
       <MenuItem>
-        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Move Calculator" />
+        <AccordionTitle
+          active={expanded}
+          index={0}
+          onClick={() => setExpanded(!expanded)}
+          content="Move Calculator"
+        />
         <AccordionContent active={expanded}>
           <div>
-            {options == null && <>
-              <Button color="green" loading={running} disabled={running} onClick={() => {
-                setRunning(true);
-                setTimeout(calculateRoutes, 0);
-              }}>Calculate Moves</Button>
-              <p>
-                Click &quot;calculate&quot; to see available moves (this might
-                take ~30 seconds).
-              </p>
-            </>}
+            {options == null && (
+              <>
+                <Button
+                  color="green"
+                  loading={running}
+                  disabled={running}
+                  onClick={() => {
+                    setRunning(true);
+                    setTimeout(calculateRoutes, 0);
+                  }}
+                >
+                  Calculate Moves
+                </Button>
+                <p>
+                  Click &quot;calculate&quot; to see available moves (this might
+                  take ~30 seconds).
+                </p>
+              </>
+            )}
             {options != null && options.length > 0 && (
               <table className={styles.table}>
                 <thead>
@@ -115,7 +136,9 @@ export function MoveCalculator() {
                 </tbody>
               </table>
             )}
-            {options != null && options.length === 0 && <p>No moves available</p>}
+            {options != null && options.length === 0 && (
+              <p>No moves available</p>
+            )}
           </div>
         </AccordionContent>
       </MenuItem>

--- a/src/client/game/options.tsx
+++ b/src/client/game/options.tsx
@@ -1,16 +1,10 @@
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Typography,
-} from "@mui/material";
-import { Button } from "semantic-ui-react";
+import {Accordion, AccordionContent, AccordionTitle, Button, Menu, MenuItem} from "semantic-ui-react";
 import { GameStatus } from "../../api/game";
 import { UsernameList } from "../components/username";
 import { useAbandon, useConcede, useGame, useKick } from "../services/game";
 import { useMe } from "../services/me";
 import * as styles from "./options.module.css";
+import {useState} from "react";
 
 export function GameOptions() {
   const game = useGame();
@@ -18,6 +12,7 @@ export function GameOptions() {
   const { concede, hasConceded, isPending: isConcedePending } = useConcede();
   const { abandon, isPending: isAbandonPending } = useAbandon();
   const { kick, isPending: isKickPending, kickTimeRemaining } = useKick();
+  const [ expanded, setExpanded ] = useState<boolean>(false);
 
   if (
     game.status !== GameStatus.enum.ACTIVE ||
@@ -28,68 +23,68 @@ export function GameOptions() {
   }
 
   return (
-    <Accordion>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Typography component="h2">Game Options</Typography>
-      </AccordionSummary>
-      <AccordionDetails>
-        <div className={styles.container}>
-          <div className={styles.row}>
-            <div className={styles.buttonContainer}>
-              <Button onClick={concede} disabled={isConcedePending}>
-                {hasConceded ? "Undo concede" : "Concede"}
-              </Button>
+    <Accordion as={Menu} fluid vertical>
+      <MenuItem>
+        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Game Options" />
+        <AccordionContent active={expanded}>
+          <div className={styles.container}>
+            <div className={styles.row}>
+              <div className={styles.buttonContainer}>
+                <Button onClick={concede} disabled={isConcedePending}>
+                  {hasConceded ? "Undo concede" : "Concede"}
+                </Button>
+              </div>
+              <p>
+                If everyone agrees to concede a game, it&apos;ll end with the
+                current lead player winning the game. This does not hurt
+                anyone&apos;s reputation.
+                {game.concedingPlayers.length !== 0 && (
+                  <>
+                    {" "}
+                    Conceding Players:{" "}
+                    <UsernameList userIds={game.concedingPlayers} />
+                  </>
+                )}
+              </p>
             </div>
-            <p>
-              If everyone agrees to concede a game, it&apos;ll end with the
-              current lead player winning the game. This does not hurt
-              anyone&apos;s reputation.
-              {game.concedingPlayers.length !== 0 && (
-                <>
-                  {" "}
-                  Conceding Players:{" "}
-                  <UsernameList userIds={game.concedingPlayers} />
-                </>
+            <div className={styles.row}>
+              <div className={styles.buttonContainer}>
+                <Button onClick={abandon} disabled={isAbandonPending}>
+                  Abandon game
+                </Button>
+              </div>
+              <p>
+                Abandoning the game causes the game to end in an abandoned state,
+                and it will hurt your reputation to do so.
+              </p>
+            </div>
+            <div className={styles.row}>
+              <div className={styles.buttonContainer}>
+                <Button
+                  onClick={kick}
+                  disabled={kickTimeRemaining != null || isKickPending}
+                >
+                  Kick current player
+                </Button>
+              </div>
+              {kickTimeRemaining == null ? (
+                <p>
+                  You can kick the current player because they took too long to
+                  play. This will end the game in an abandoned state, and hurt the
+                  reputation of the player being kicked.
+                </p>
+              ) : (
+                <p>
+                  The current player has {kickTimeRemaining} remaining. Once that
+                  time is up, you can kick the current player. This will end the
+                  game in an abandoned state and hurt the reputation of the
+                  current player.
+                </p>
               )}
-            </p>
-          </div>
-          <div className={styles.row}>
-            <div className={styles.buttonContainer}>
-              <Button onClick={abandon} disabled={isAbandonPending}>
-                Abandon game
-              </Button>
             </div>
-            <p>
-              Abandoning the game causes the game to end in an abandoned state,
-              and it will hurt your reputation to do so.
-            </p>
           </div>
-          <div className={styles.row}>
-            <div className={styles.buttonContainer}>
-              <Button
-                onClick={kick}
-                disabled={kickTimeRemaining != null || isKickPending}
-              >
-                Kick current player
-              </Button>
-            </div>
-            {kickTimeRemaining == null ? (
-              <p>
-                You can kick the current player because they took too long to
-                play. This will end the game in an abandoned state, and hurt the
-                reputation of the player being kicked.
-              </p>
-            ) : (
-              <p>
-                The current player has {kickTimeRemaining} remaining. Once that
-                time is up, you can kick the current player. This will end the
-                game in an abandoned state and hurt the reputation of the
-                current player.
-              </p>
-            )}
-          </div>
-        </div>
-      </AccordionDetails>
+        </AccordionContent>
+      </MenuItem>
     </Accordion>
   );
 }

--- a/src/client/game/options.tsx
+++ b/src/client/game/options.tsx
@@ -1,10 +1,17 @@
-import {Accordion, AccordionContent, AccordionTitle, Button, Menu, MenuItem} from "semantic-ui-react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionTitle,
+  Button,
+  Menu,
+  MenuItem,
+} from "semantic-ui-react";
 import { GameStatus } from "../../api/game";
 import { UsernameList } from "../components/username";
 import { useAbandon, useConcede, useGame, useKick } from "../services/game";
 import { useMe } from "../services/me";
 import * as styles from "./options.module.css";
-import {useState} from "react";
+import { useState } from "react";
 
 export function GameOptions() {
   const game = useGame();
@@ -12,7 +19,7 @@ export function GameOptions() {
   const { concede, hasConceded, isPending: isConcedePending } = useConcede();
   const { abandon, isPending: isAbandonPending } = useAbandon();
   const { kick, isPending: isKickPending, kickTimeRemaining } = useKick();
-  const [ expanded, setExpanded ] = useState<boolean>(false);
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   if (
     game.status !== GameStatus.enum.ACTIVE ||
@@ -25,7 +32,12 @@ export function GameOptions() {
   return (
     <Accordion as={Menu} fluid vertical>
       <MenuItem>
-        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Game Options" />
+        <AccordionTitle
+          active={expanded}
+          index={0}
+          onClick={() => setExpanded(!expanded)}
+          content="Game Options"
+        />
         <AccordionContent active={expanded}>
           <div className={styles.container}>
             <div className={styles.row}>
@@ -54,8 +66,8 @@ export function GameOptions() {
                 </Button>
               </div>
               <p>
-                Abandoning the game causes the game to end in an abandoned state,
-                and it will hurt your reputation to do so.
+                Abandoning the game causes the game to end in an abandoned
+                state, and it will hurt your reputation to do so.
               </p>
             </div>
             <div className={styles.row}>
@@ -70,15 +82,15 @@ export function GameOptions() {
               {kickTimeRemaining == null ? (
                 <p>
                   You can kick the current player because they took too long to
-                  play. This will end the game in an abandoned state, and hurt the
-                  reputation of the player being kicked.
+                  play. This will end the game in an abandoned state, and hurt
+                  the reputation of the player being kicked.
                 </p>
               ) : (
                 <p>
-                  The current player has {kickTimeRemaining} remaining. Once that
-                  time is up, you can kick the current player. This will end the
-                  game in an abandoned state and hurt the reputation of the
-                  current player.
+                  The current player has {kickTimeRemaining} remaining. Once
+                  that time is up, you can kick the current player. This will
+                  end the game in an abandoned state and hurt the reputation of
+                  the current player.
                 </p>
               )}
             </div>

--- a/src/client/game/player_stats.module.css
+++ b/src/client/game/player_stats.module.css
@@ -1,7 +1,3 @@
-.playerStatsContainer {
-  margin: 8px 0;
-}
-
 .playerStats {
   overflow-y: auto;
 }
@@ -32,8 +28,8 @@
   }
 }
 
-svg.user {
-  fill: var(--player-color);
+:global(i.icon).user {
+  color: var(--player-color);
   /* background-color: var(--player-color-text);
   border-radius: 50%; */
 }

--- a/src/client/game/player_stats.tsx
+++ b/src/client/game/player_stats.tsx
@@ -27,7 +27,14 @@ import { FinalOverview } from "./final_overview";
 import { LoginButton } from "./login_button";
 
 import * as styles from "./player_stats.module.css";
-import {Accordion, AccordionTitle, AccordionContent, Icon, Segment, Header, Menu, MenuItem} from "semantic-ui-react";
+import {
+  Accordion,
+  AccordionTitle,
+  AccordionContent,
+  Icon,
+  Menu,
+  MenuItem,
+} from "semantic-ui-react";
 
 export function PlayerStats() {
   const playerData = useInject(() => injectAllPlayersUnsafe()(), []);
@@ -63,7 +70,12 @@ export function PlayerStats() {
   return (
     <Accordion fluid as={Menu} vertical>
       <MenuItem>
-        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Player overview" />
+        <AccordionTitle
+          active={expanded}
+          index={0}
+          onClick={() => setExpanded(!expanded)}
+          content="Player overview"
+        />
         <AccordionContent active={expanded}>
           <div className={styles.playerStats}>
             <table>

--- a/src/client/game/player_stats.tsx
+++ b/src/client/game/player_stats.tsx
@@ -1,13 +1,4 @@
-import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRightTwoTone";
-import Circle from "@mui/icons-material/Circle";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Typography,
-} from "@mui/material";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { GameStatus } from "../../api/game";
 import { PlayerHelper } from "../../engine/game/player";
 import {
@@ -36,11 +27,13 @@ import { FinalOverview } from "./final_overview";
 import { LoginButton } from "./login_button";
 
 import * as styles from "./player_stats.module.css";
+import {Accordion, AccordionTitle, AccordionContent, Icon, Segment, Header, Menu, MenuItem} from "semantic-ui-react";
 
 export function PlayerStats() {
   const playerData = useInject(() => injectAllPlayersUnsafe()(), []);
   const playerOrder = useInjectedState(TURN_ORDER);
   const currentPlayer = useActiveGameState(CURRENT_PLAYER);
+  const [expanded, setExpanded] = useState<boolean>(true);
   const outOfGamePlayers = playerData
     .filter((p) => p.outOfGame)
     .map((p) => p.color);
@@ -68,12 +61,10 @@ export function PlayerStats() {
   ];
 
   return (
-    <div className={styles.playerStatsContainer}>
-      <Accordion defaultExpanded>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography component="h2">Player overview</Typography>
-        </AccordionSummary>
-        <AccordionDetails>
+    <Accordion fluid as={Menu} vertical>
+      <MenuItem>
+        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Player overview" />
+        <AccordionContent active={expanded}>
           <div className={styles.playerStats}>
             <table>
               <thead>
@@ -137,9 +128,9 @@ export function PlayerStats() {
               </tbody>
             </table>
           </div>
-        </AccordionDetails>
-      </Accordion>
-    </div>
+        </AccordionContent>
+      </MenuItem>
+    </Accordion>
   );
 }
 
@@ -239,9 +230,9 @@ export function PlayerColorIndicator({
 }: PlayerColorIndicatorProps) {
   const className = `${styles.user} ${getPlayerColorCss(playerColor)}`;
   return currentTurn ? (
-    <ArrowCircleRightIcon fontSize="large" className={className} />
+    <Icon name="arrow circle right" size="large" className={className} />
   ) : (
-    <Circle fontSize="large" className={className} />
+    <Icon name="circle" size="large" className={className} />
   );
 }
 

--- a/src/client/game/special_action_table.module.css
+++ b/src/client/game/special_action_table.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   gap: 12px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .specialAction {

--- a/src/client/game/special_action_table.tsx
+++ b/src/client/game/special_action_table.tsx
@@ -19,7 +19,7 @@ export function SpecialActionTable() {
   const actions = useInjected(AllowedActions);
 
   return (
-    <div>
+    <div style={{marginTop: "1em"}}>
       <h2>Special Actions</h2>
       <div className={styles.specialActionTable}>
         {actions.getActions().map((action) => (

--- a/src/client/game/tile_manifest.tsx
+++ b/src/client/game/tile_manifest.tsx
@@ -1,11 +1,4 @@
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Typography,
-} from "@mui/material";
-import { useMemo } from "react";
+import {useMemo, useState} from "react";
 import { BuilderHelper, TileManifestEntry } from "../../engine/build/helper";
 import { inject } from "../../engine/framework/execution_context";
 import { Grid } from "../../engine/map/grid";
@@ -18,22 +11,25 @@ import { Coordinates } from "../../utils/coordinates";
 import { HexGrid } from "../grid/hex_grid";
 import { useGameKey, useInject } from "../utils/injection_context";
 import * as styles from "./tile_manifest.module.css";
+import {Accordion, AccordionContent, AccordionTitle, Menu, MenuItem} from "semantic-ui-react";
 
 export function TileManifest() {
   const manifest = useInject(() => inject(BuilderHelper).trackManifest(), []);
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   return (
-    <Accordion>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Typography component="h2">Tile Manifest</Typography>
-      </AccordionSummary>
-      <AccordionDetails>
-        <div className={styles.tiles}>
-          {[...manifest.entries()].map(([tileType, info]) => (
-            <TileInfo key={tileType} tileType={tileType} info={info} />
-          ))}
-        </div>
-      </AccordionDetails>
+    <Accordion as={Menu} vertical fluid>
+      <MenuItem>
+        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Tile Manifest" />
+        <AccordionContent active={expanded}>
+          {expanded && (
+          <div className={styles.tiles}>
+            {[...manifest.entries()].map(([tileType, info]) => (
+              <TileInfo key={tileType} tileType={tileType} info={info} />
+            ))}
+          </div>)}
+        </AccordionContent>
+      </MenuItem>
     </Accordion>
   );
 }

--- a/src/client/game/tile_manifest.tsx
+++ b/src/client/game/tile_manifest.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from "react";
+import { useMemo, useState } from "react";
 import { BuilderHelper, TileManifestEntry } from "../../engine/build/helper";
 import { inject } from "../../engine/framework/execution_context";
 import { Grid } from "../../engine/map/grid";
@@ -11,7 +11,13 @@ import { Coordinates } from "../../utils/coordinates";
 import { HexGrid } from "../grid/hex_grid";
 import { useGameKey, useInject } from "../utils/injection_context";
 import * as styles from "./tile_manifest.module.css";
-import {Accordion, AccordionContent, AccordionTitle, Menu, MenuItem} from "semantic-ui-react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionTitle,
+  Menu,
+  MenuItem,
+} from "semantic-ui-react";
 
 export function TileManifest() {
   const manifest = useInject(() => inject(BuilderHelper).trackManifest(), []);
@@ -20,14 +26,20 @@ export function TileManifest() {
   return (
     <Accordion as={Menu} vertical fluid>
       <MenuItem>
-        <AccordionTitle active={expanded} index={0} onClick={() => setExpanded(!expanded)} content="Tile Manifest" />
+        <AccordionTitle
+          active={expanded}
+          index={0}
+          onClick={() => setExpanded(!expanded)}
+          content="Tile Manifest"
+        />
         <AccordionContent active={expanded}>
           {expanded && (
-          <div className={styles.tiles}>
-            {[...manifest.entries()].map(([tileType, info]) => (
-              <TileInfo key={tileType} tileType={tileType} info={info} />
-            ))}
-          </div>)}
+            <div className={styles.tiles}>
+              {[...manifest.entries()].map(([tileType, info]) => (
+                <TileInfo key={tileType} tileType={tileType} info={info} />
+              ))}
+            </div>
+          )}
         </AccordionContent>
       </MenuItem>
     </Accordion>

--- a/src/client/home/game_card.tsx
+++ b/src/client/home/game_card.tsx
@@ -4,7 +4,8 @@ import {
   CardContent,
   CardDescription,
   CardHeader,
-  CardMeta, Icon,
+  CardMeta,
+  Icon,
 } from "semantic-ui-react";
 import { Link } from "react-router-dom";
 import {
@@ -174,7 +175,13 @@ export function DeleteButton({ game }: GameButtonProps) {
   }
 
   return (
-    <Button icon labelPosition="left" negative disabled={isPending} onClick={perform}>
+    <Button
+      icon
+      labelPosition="left"
+      negative
+      disabled={isPending}
+      onClick={perform}
+    >
       <Icon name="delete" />
       Delete
     </Button>

--- a/src/client/home/game_card.tsx
+++ b/src/client/home/game_card.tsx
@@ -4,7 +4,7 @@ import {
   CardContent,
   CardDescription,
   CardHeader,
-  CardMeta,
+  CardMeta, Icon,
 } from "semantic-ui-react";
 import { Link } from "react-router-dom";
 import {
@@ -174,7 +174,8 @@ export function DeleteButton({ game }: GameButtonProps) {
   }
 
   return (
-    <Button negative disabled={isPending} onClick={perform}>
+    <Button icon labelPosition="left" negative disabled={isPending} onClick={perform}>
+      <Icon name="delete" />
       Delete
     </Button>
   );

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -19,6 +19,13 @@ body.dark-mode {
   background-color: inherit;
 }
 
+.ui.accordion.menu .item .title {
+  font-size: 1.1em;
+}
+.ui.accordion.menu .item .active.title {
+  margin-bottom: 1em;
+}
+
 /* Dark mode semantic-ui components, with styling copied from the default "inverted" components. */
 body.dark-mode,
 body.dark-mode .ui.header {


### PR DESCRIPTION
Continuing the semantic UI transition, this touches pretty much everything on the active game page. (After this I'd expect 1 more big PR that finishes the transition on the rest of the misc pages.)

I might come back and do some more minor tweaks to the UI once to refactor is done, but for now this is mostly a mechanical change and doesn't change much for the end-user.

![Screenshot 2025-05-27 at 18 08 42](https://github.com/user-attachments/assets/eb0793b8-b055-4b99-98ca-94486578b772)
