### PR TITLE
Extract move interceptor logic into game-specific components.

### DIFF
--- a/src/client/grid/good.module.css
+++ b/src/client/grid/good.module.css
@@ -17,3 +17,7 @@
 .yellow {
   --good-color: #f5ac11;
 }
+
+.white {
+  --good-color: #e9dcc9;
+}

--- a/src/client/grid/good.ts
+++ b/src/client/grid/good.ts
@@ -14,6 +14,8 @@ export function goodStyle(good: Good): string {
       return styles.red;
     case Good.YELLOW:
       return styles.yellow;
+    case Good.WHITE:
+      return styles.white;
     default:
       assertNever(good);
   }

--- a/src/client/grid/move_intercept.tsx
+++ b/src/client/grid/move_intercept.tsx
@@ -1,28 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
-import {
-  Button,
-  DropdownProps,
-  Header,
-  Modal,
-  ModalActions,
-  ModalContent,
-  Select,
-} from "semantic-ui-react";
-import { GameKey } from "../../api/game_key";
+import { useCallback, useState } from "react";
 import { MoveData } from "../../engine/move/move";
-import { PlayerColor, playerColorToString } from "../../engine/state/player";
-import {
-  AlabamaMoveAction,
-  AlabamaMoveData,
-} from "../../maps/alabama_railways/move_good";
-import { MoonMoveAction } from "../../maps/moon/low_gravitation";
-import * as styles from "../components/confirm.module.css";
-import { useAction } from "../services/action";
-import {
-  useCurrentPlayer,
-  useGameKey,
-  useInjectedMemo,
-} from "../utils/injection_context";
+import { useGameKey, useInjected } from "../utils/injection_context";
+import { MoveInterceptor } from "../../engine/move/interceptor";
+import { ViewRegistry } from "../../maps/view_registry";
 
 interface InterceptMoveModalProps {
   cityName?: string;
@@ -31,10 +11,7 @@ interface InterceptMoveModalProps {
 }
 
 export function useMoveInterceptionState() {
-  const gameKey = useGameKey();
-  const moonMoveAction = useInjectedMemo(MoonMoveAction);
-  const { canEmit: canEmitMoonMove } = useAction(MoonMoveAction);
-  const currentPlayer = useCurrentPlayer()?.color;
+  const moveInterceptor = useInjected(MoveInterceptor);
   const [[cityName, moveData], setInternalState] = useState<
     [string, MoveData] | [undefined, undefined]
   >([undefined, undefined]);
@@ -43,28 +20,14 @@ export function useMoveInterceptionState() {
   }, []);
   const maybeInterceptMove = useCallback(
     (moveData: MoveData, cityName: string) => {
-      const hasAChoice =
-        currentPlayer != null &&
-        moveData.path.some(({ owner }) => owner !== currentPlayer);
-      if (gameKey === GameKey.ALABAMA_RAILWAYS) {
-        if (!hasAChoice) {
-          (moveData as AlabamaMoveData).forgo = moveData.path[0].owner;
-          return false;
-        }
-        setInternalState([cityName, moveData]);
-        return true;
-      }
-      if (
-        gameKey === GameKey.MOON &&
-        hasAChoice &&
-        moonMoveAction.value.hasLowGravitation()
-      ) {
+      const intercept = moveInterceptor.shouldInterceptMove(moveData, cityName);
+      if (intercept) {
         setInternalState([cityName, moveData]);
         return true;
       }
       return false;
     },
-    [canEmitMoonMove, moonMoveAction, gameKey, setInternalState, currentPlayer],
+    [setInternalState, moveInterceptor],
   );
   return {
     moveData,
@@ -74,123 +37,12 @@ export function useMoveInterceptionState() {
   };
 }
 
-const NO_ONE = "NO_ONE" as const;
-
-type SelectedPlayer = PlayerColor | typeof NO_ONE;
-
-export function InterceptMoveModal({
-  cityName,
-  moveData,
-  clearMoveData: clearMoveDataExternal,
-}: InterceptMoveModalProps) {
+export function InterceptMoveModal(props: InterceptMoveModalProps) {
   const gameKey = useGameKey();
-  const { emit: emitMoonMoveAction, isPending: isMoonPending } =
-    useAction(MoonMoveAction);
-  const { emit: emitAlabamaMoveAction, isPending: isAlabamaPending } =
-    useAction(AlabamaMoveAction);
-  const isPending = isMoonPending || isAlabamaPending;
-
-  const [selectedPlayer, setSelectedPlayer] = useState<
-    SelectedPlayer | undefined
-  >(NO_ONE);
-  const currentPlayer = useCurrentPlayer();
-
-  const clearMoveData = useCallback(() => {
-    clearMoveDataExternal();
-    setSelectedPlayer(NO_ONE);
-  }, [clearMoveDataExternal, setSelectedPlayer]);
-
-  const options = useMemo(() => {
-    if (moveData == null) return [];
-    const { path } = moveData;
-    const players = new Set(
-      path
-        .map((p) => p.owner)
-        .filter((p) =>
-          gameKey === GameKey.MOON ? p != currentPlayer?.color : true,
-        ),
-    );
-    return [
-      {
-        key: NO_ONE,
-        text: gameKey === GameKey.MOON ? "Don't use LG" : "",
-        value: NO_ONE,
-      },
-      ...[...players].map((p) => ({
-        key: p == null ? "--Unowned--" : p,
-        text: p == null ? "Unowned link" : playerColorToString(p),
-        value: p,
-      })),
-    ];
-  }, [moveData, currentPlayer?.color]);
-
-  const completeMove = useCallback(() => {
-    if (gameKey === GameKey.MOON) {
-      emitMoonMoveAction({
-        ...moveData!,
-        stealFrom:
-          selectedPlayer === NO_ONE ? undefined : { color: selectedPlayer },
-      });
-    } else {
-      if (selectedPlayer === NO_ONE) return;
-      emitAlabamaMoveAction({
-        forgo: selectedPlayer,
-        ...moveData!,
-      });
-    }
-    clearMoveData();
-    setSelectedPlayer(NO_ONE);
-  }, [
-    gameKey,
-    emitMoonMoveAction,
-    emitAlabamaMoveAction,
-    clearMoveData,
-    moveData,
-    selectedPlayer,
-  ]);
-
-  const onChange = useCallback(
-    (_: unknown, { value }: DropdownProps) => {
-      setSelectedPlayer(value as SelectedPlayer | undefined);
-    },
-    [setSelectedPlayer],
-  );
-
-  return (
-    <Modal
-      className={styles.modal}
-      closeIcon
-      open={moveData != null}
-      onClose={clearMoveData}
-    >
-      <Header className={styles.modal} content={`Deliver to ${cityName}?`} />
-      <ModalContent>
-        {gameKey === GameKey.MOON && (
-          <p>
-            Optionally, you can use low gravitation to use a player&apos;s link.
-          </p>
-        )}
-        {gameKey === GameKey.ALABAMA_RAILWAYS && (
-          <p>Select a player to miss out on income.</p>
-        )}
-        <Select
-          placeholder="Player link"
-          options={options}
-          onChange={onChange}
-        />
-      </ModalContent>
-      <ModalActions>
-        <Button onClick={clearMoveData} disabled={isPending}>
-          Cancel
-        </Button>
-        <Button onClick={completeMove} disabled={isPending}>
-          {gameKey === GameKey.ALABAMA_RAILWAYS
-            ? "Select Player"
-            : selectedPlayer === NO_ONE
-              ? "Continue without using low gravitation"
-              : "Use low gravitation"}
-        </Button>
-      </ModalActions>
-    </Modal>
-  );
+  const mapSettings = ViewRegistry.singleton.get(gameKey);
+  if (!mapSettings.moveInterceptModal) {
+    return null;
+  }
+  const Modal = mapSettings.moveInterceptModal;
+  return <Modal {...props} />;
 }

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -70,7 +70,8 @@ body.dark-mode .ui.vertical.menu.accordion {
 body.dark-mode .ui.menu.accordion .item {
   color: rgba(255, 255, 255, 0.9);
 }
-body.dark-mode .ui.checkbox label, body.dark-mode .ui.checkbox + label {
+body.dark-mode .ui.checkbox label,
+body.dark-mode .ui.checkbox + label {
   color: rgba(255, 255, 255, 0.9) !important;
 }
 body.dark-mode .ui.form .inline.field > label,
@@ -80,8 +81,13 @@ body.dark-mode .ui.form .inline.fields .field > p,
 body.dark-mode .ui.form .inline.fields > label {
   color: rgba(255, 255, 255, 0.9);
 }
-body.dark-mode .ui.inverted.input > input {
+body.dark-mode .ui.input > input {
   border: none;
+}
+/* This does not apply dark mode to modals, but ensures text is visible on non-inverted modal even in dark mode. */
+body.dark-mode .ui.modal,
+body.dark-mode .ui.modal > .header {
+  color: black;
 }
 
 /**

--- a/src/engine/move/interceptor.ts
+++ b/src/engine/move/interceptor.ts
@@ -1,0 +1,13 @@
+import { MoveData } from "./move";
+
+export interface InterceptMoveModalProps {
+  cityName?: string;
+  moveData?: MoveData;
+  clearMoveData(): void;
+}
+
+export class MoveInterceptor {
+  public shouldInterceptMove(_moveData: MoveData, _cityName: string): boolean {
+    return false;
+  }
+}

--- a/src/maps/alabama_railways/move_interceptor.ts
+++ b/src/maps/alabama_railways/move_interceptor.ts
@@ -1,0 +1,21 @@
+import { MoveData } from "../../engine/move/move";
+import { AlabamaMoveData } from "./move_good";
+import { MoveInterceptor } from "../../engine/move/interceptor";
+import { injectCurrentPlayer } from "../../engine/game/state";
+
+export class AlabamaRailwaysMoveInterceptor extends MoveInterceptor {
+  private readonly currentPlayer = injectCurrentPlayer();
+
+  public shouldInterceptMove(moveData: MoveData, _cityName: string): boolean {
+    const player = this.currentPlayer();
+
+    const hasAChoice =
+      player != null &&
+      moveData.path.some(({ owner }) => owner !== player.color);
+    if (!hasAChoice) {
+      (moveData as AlabamaMoveData).forgo = moveData.path[0].owner;
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/maps/alabama_railways/move_interceptor_modal.tsx
+++ b/src/maps/alabama_railways/move_interceptor_modal.tsx
@@ -1,0 +1,93 @@
+import { InterceptMoveModalProps } from "../../engine/move/interceptor";
+import { useAction } from "../../client/services/action";
+import { AlabamaMoveAction } from "./move_good";
+import { useCallback, useMemo, useState } from "react";
+import { useCurrentPlayer } from "../../client/utils/injection_context";
+import { PlayerColor, playerColorToString } from "../../engine/state/player";
+import {
+  Button,
+  DropdownProps,
+  Header,
+  Modal,
+  ModalActions,
+  ModalContent,
+  Select,
+} from "semantic-ui-react";
+
+const NO_ONE = "NO_ONE" as const;
+type SelectedPlayer = PlayerColor | typeof NO_ONE;
+
+export function AlabamaRailwaysMoveInterceptorModal({
+  cityName,
+  moveData,
+  clearMoveData: clearMoveDataExternal,
+}: InterceptMoveModalProps) {
+  const { emit: emitAlabamaMoveAction, isPending: isPending } =
+    useAction(AlabamaMoveAction);
+  const [selectedPlayer, setSelectedPlayer] = useState<
+    SelectedPlayer | undefined
+  >(NO_ONE);
+  const currentPlayer = useCurrentPlayer();
+
+  const clearMoveData = useCallback(() => {
+    clearMoveDataExternal();
+    setSelectedPlayer(NO_ONE);
+  }, [clearMoveDataExternal, setSelectedPlayer]);
+
+  const options = useMemo(() => {
+    if (moveData == null) return [];
+    const { path } = moveData;
+    const players = new Set(path.map((p) => p.owner));
+    return [
+      {
+        key: NO_ONE,
+        text: "",
+        value: NO_ONE,
+      },
+      ...[...players].map((p) => ({
+        key: p == null ? "--Unowned--" : p,
+        text: p == null ? "Unowned link" : playerColorToString(p),
+        value: p,
+      })),
+    ];
+  }, [moveData, currentPlayer?.color]);
+
+  const completeMove = useCallback(() => {
+    if (selectedPlayer === NO_ONE) return;
+    emitAlabamaMoveAction({
+      forgo: selectedPlayer,
+      ...moveData!,
+    });
+    clearMoveData();
+    setSelectedPlayer(NO_ONE);
+  }, [emitAlabamaMoveAction, clearMoveData, moveData, selectedPlayer]);
+
+  const onChange = useCallback(
+    (_: unknown, { value }: DropdownProps) => {
+      setSelectedPlayer(value as SelectedPlayer | undefined);
+    },
+    [setSelectedPlayer],
+  );
+
+  return (
+    <Modal closeIcon open={moveData != null} onClose={clearMoveData}>
+      <Header content={`Deliver to ${cityName}?`} />
+      <ModalContent>
+        <p>Select a player to miss out on income.</p>
+        <Select
+          placeholder="Player link"
+          options={options}
+          onChange={onChange}
+        />
+      </ModalContent>
+      <ModalActions>
+        <Button onClick={clearMoveData} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button onClick={completeMove} disabled={isPending}>
+          Select Player
+        </Button>
+      </ModalActions>
+    </Modal>
+  );
+}

--- a/src/maps/alabama_railways/settings.ts
+++ b/src/maps/alabama_railways/settings.ts
@@ -7,6 +7,7 @@ import { map } from "./grid";
 import { AlabamaGoodsGrowthPhase } from "./growth";
 import { AlabamaMoveAction } from "./move_good";
 import { AlabamaRailwaysStarter } from "./starter";
+import { AlabamaRailwaysMoveInterceptor } from "./move_interceptor";
 
 export class AlabamaRailwaysMapSettings implements MapSettings {
   readonly key = GameKey.ALABAMA_RAILWAYS;
@@ -17,7 +18,12 @@ export class AlabamaRailwaysMapSettings implements MapSettings {
   readonly stage = ReleaseStage.ALPHA;
 
   getOverrides() {
-    return [AlabamaRailwaysStarter, AlabamaMoveAction, AlabamaGoodsGrowthPhase];
+    return [
+      AlabamaRailwaysStarter,
+      AlabamaMoveAction,
+      AlabamaGoodsGrowthPhase,
+      AlabamaRailwaysMoveInterceptor,
+    ];
   }
 
   getModules() {

--- a/src/maps/alabama_railways/view_settings.ts
+++ b/src/maps/alabama_railways/view_settings.ts
@@ -2,6 +2,7 @@ import { MapViewSettings } from "../view_settings";
 import { AlabamaRivers } from "./rivers";
 import { AlabamaRailwaysRules } from "./rules";
 import { AlabamaRailwaysMapSettings } from "./settings";
+import { AlabamaRailwaysMoveInterceptorModal } from "./move_interceptor_modal";
 
 export class AlabamaRailwaysViewSettings
   extends AlabamaRailwaysMapSettings
@@ -10,4 +11,6 @@ export class AlabamaRailwaysViewSettings
   getMapRules = AlabamaRailwaysRules;
 
   getTexturesLayer = AlabamaRivers;
+
+  moveInterceptModal = AlabamaRailwaysMoveInterceptorModal;
 }

--- a/src/maps/moon/move_interceptor.ts
+++ b/src/maps/moon/move_interceptor.ts
@@ -1,0 +1,20 @@
+import { MoveData } from "../../engine/move/move";
+import { MoveInterceptor } from "../../engine/move/interceptor";
+import { injectCurrentPlayer } from "../../engine/game/state";
+import { Action } from "../../engine/state/action";
+
+export class MoonMoveInterceptor extends MoveInterceptor {
+  private readonly currentPlayer = injectCurrentPlayer();
+
+  public shouldInterceptMove(moveData: MoveData, _cityName: string): boolean {
+    const player = this.currentPlayer();
+
+    const hasAChoice =
+      player != null &&
+      moveData.path.some(({ owner }) => owner !== player.color);
+    if (hasAChoice && player.selectedAction === Action.LOW_GRAVITATION) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/maps/moon/move_interceptor_modal.tsx
+++ b/src/maps/moon/move_interceptor_modal.tsx
@@ -1,0 +1,106 @@
+import { InterceptMoveModalProps } from "../../engine/move/interceptor";
+import { useAction } from "../../client/services/action";
+import React, { useCallback, useMemo, useState } from "react";
+import { useCurrentPlayer } from "../../client/utils/injection_context";
+import { PlayerColor, playerColorToString } from "../../engine/state/player";
+import {
+  Button,
+  DropdownProps,
+  Header,
+  Modal,
+  ModalActions,
+  ModalContent,
+  Select,
+} from "semantic-ui-react";
+import { MoonMoveAction } from "./low_gravitation";
+import * as styles from "../../client/components/confirm.module.css";
+
+const NO_ONE = "NO_ONE" as const;
+type SelectedPlayer = PlayerColor | typeof NO_ONE;
+
+export function MoonMoveInterceptorModal({
+  cityName,
+  moveData,
+  clearMoveData: clearMoveDataExternal,
+}: InterceptMoveModalProps) {
+  const { emit: emitMoonMoveAction, isPending: isPending } =
+    useAction(MoonMoveAction);
+
+  const [selectedPlayer, setSelectedPlayer] = useState<
+    SelectedPlayer | undefined
+  >(NO_ONE);
+  const currentPlayer = useCurrentPlayer();
+
+  const clearMoveData = useCallback(() => {
+    clearMoveDataExternal();
+    setSelectedPlayer(NO_ONE);
+  }, [clearMoveDataExternal, setSelectedPlayer]);
+
+  const options = useMemo(() => {
+    if (moveData == null) return [];
+    const { path } = moveData;
+    const players = new Set(
+      path.map((p) => p.owner).filter((p) => p != currentPlayer?.color),
+    );
+    return [
+      {
+        key: NO_ONE,
+        text: "Don't use LG",
+        value: NO_ONE,
+      },
+      ...[...players].map((p) => ({
+        key: p == null ? "--Unowned--" : p,
+        text: p == null ? "Unowned link" : playerColorToString(p),
+        value: p,
+      })),
+    ];
+  }, [moveData, currentPlayer?.color]);
+
+  const completeMove = useCallback(() => {
+    emitMoonMoveAction({
+      ...moveData!,
+      stealFrom:
+        selectedPlayer === NO_ONE ? undefined : { color: selectedPlayer },
+    });
+    clearMoveData();
+    setSelectedPlayer(NO_ONE);
+  }, [emitMoonMoveAction, clearMoveData, moveData, selectedPlayer]);
+
+  const onChange = useCallback(
+    (_: unknown, { value }: DropdownProps) => {
+      setSelectedPlayer(value as SelectedPlayer | undefined);
+    },
+    [setSelectedPlayer],
+  );
+
+  return (
+    <Modal
+      className={styles.modal}
+      closeIcon
+      open={moveData != null}
+      onClose={clearMoveData}
+    >
+      <Header className={styles.modal} content={`Deliver to ${cityName}?`} />
+      <ModalContent>
+        <p>
+          Optionally, you can use low gravitation to use a player&apos;s link.
+        </p>
+        <Select
+          placeholder="Player link"
+          options={options}
+          onChange={onChange}
+        />
+      </ModalContent>
+      <ModalActions>
+        <Button onClick={clearMoveData} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button onClick={completeMove} disabled={isPending}>
+          {selectedPlayer === NO_ONE
+            ? "Continue without using low gravitation"
+            : "Use low gravitation"}
+        </Button>
+      </ModalActions>
+    </Modal>
+  );
+}

--- a/src/maps/moon/settings.ts
+++ b/src/maps/moon/settings.ts
@@ -12,6 +12,7 @@ import { map } from "./grid";
 import { MoonAllowedActions, MoonMoveAction } from "./low_gravitation";
 import { MoonStarter } from "./starter";
 import { getNeighbor } from "./wrap_around";
+import { MoonMoveInterceptor } from "./move_interceptor";
 
 export class MoonMapSettings implements MapSettings {
   readonly key = GameKey.MOON;
@@ -33,6 +34,7 @@ export class MoonMapSettings implements MapSettings {
       MoonMoveAction,
       MoonAllowedActions,
       MoonUrbanizeAction,
+      MoonMoveInterceptor,
     ];
   }
 

--- a/src/maps/moon/view_settings.ts
+++ b/src/maps/moon/view_settings.ts
@@ -2,6 +2,7 @@ import { MapViewSettings } from "../view_settings";
 import { MoonRules } from "./rules";
 import { MoonMapSettings } from "./settings";
 import { MoonTextures } from "./textures";
+import { MoonMoveInterceptorModal } from "./move_interceptor_modal";
 
 export class MoonViewSettings
   extends MoonMapSettings
@@ -10,4 +11,6 @@ export class MoonViewSettings
   getMapRules = MoonRules;
 
   getTexturesLayer = MoonTextures;
+
+  moveInterceptModal = MoonMoveInterceptorModal;
 }

--- a/src/maps/sweden/recycling.ts
+++ b/src/maps/sweden/recycling.ts
@@ -62,6 +62,7 @@ export class SwedenMovePhase extends MovePhase {
   protected getNextGood(good: Good): Good {
     assert(good !== Good.PURPLE);
     assert(good !== Good.BLACK);
+    assert(good !== Good.WHITE);
     switch (good) {
       case Good.YELLOW:
         return Good.RED;

--- a/src/maps/view_settings.ts
+++ b/src/maps/view_settings.ts
@@ -3,6 +3,7 @@ import { VariantConfig } from "../api/variant_config";
 import { RowFactory } from "../client/game/final_overview_row";
 import { MapSettings } from "../engine/game/map_settings";
 import { Action } from "../engine/state/action";
+import { InterceptMoveModalProps } from "../engine/move/interceptor";
 
 export interface VariantConfigProps {
   config: Partial<VariantConfig>;
@@ -27,4 +28,5 @@ export interface MapViewSettings extends MapSettings {
   getFinalOverviewRows?(): RowFactory[];
   getActionCaption?(action: Action): string | undefined;
   moveGoodsMessage?(): string | undefined;
+  moveInterceptModal?(props: InterceptMoveModalProps): ReactNode;
 }


### PR DESCRIPTION
I was working on a JCL map with instant production, and leveraging the move interceptor seemed to be the right place, but the logic for whether to prompt (always) and what needs to be selected in the modal is significantly different. So it seemed to make more sense to extract the logic and modal to map-specific implementations.