### PR TITLE
Make union fees table render better on mobile.

### DIFF
--- a/src/maps/london/rules.tsx
+++ b/src/maps/london/rules.tsx
@@ -28,7 +28,7 @@ export function LondonRules() {
             have built.
           </p>
           <div style={{ marginBottom: "1em" }}>
-            <Table celled compact collapsing>
+            <Table celled compact collapsing unstackable>
               <TableHeader>
                 <TableRow>
                   <TableHeaderCell># Tiles</TableHeaderCell>


### PR DESCRIPTION
Realized last night that the table gets stacked on mobile which is quite silly.