### PR TITLE
Improve instant production vizualization

### DIFF
--- a/src/maps/london/move_interceptor_modal.module.css
+++ b/src/maps/london/move_interceptor_modal.module.css
@@ -1,0 +1,13 @@
+.cityOption {
+  display: inline-block;
+  border: 2px solid black;
+  border-radius: 1px;
+  cursor: pointer;
+  padding: 8px;
+  margin: 4px;
+  text-align: center;
+}
+
+.cityOption.selected {
+  border: 2px solid orange;
+}

--- a/src/maps/london/move_interceptor_modal.tsx
+++ b/src/maps/london/move_interceptor_modal.tsx
@@ -2,18 +2,22 @@ import { InterceptMoveModalProps } from "../../engine/move/interceptor";
 import { useAction } from "../../client/services/action";
 import { LondonMoveAction } from "./move_good";
 import { useCallback, useMemo, useState } from "react";
-import { useGrid } from "../../client/utils/injection_context";
+import { useGameKey, useGrid } from "../../client/utils/injection_context";
 import {
   Button,
-  DropdownProps,
   Header,
   Modal,
   ModalActions,
   ModalContent,
-  Select,
 } from "semantic-ui-react";
 import { City } from "../../engine/map/city";
 import { Coordinates } from "../../utils/coordinates";
+import * as styles from "./move_interceptor_modal.module.css";
+import { MapRegistry } from "../registry";
+import { Grid } from "../../engine/map/grid";
+import { HexGrid } from "../../client/grid/hex_grid";
+import { assert } from "../../utils/validate";
+import { Good, goodToString } from "../../engine/state/good";
 
 export function LondonMoveInterceptorModal({
   cityName,
@@ -23,7 +27,7 @@ export function LondonMoveInterceptorModal({
   const grid = useGrid();
   const { emit: emitMoveAction, isPending: isPending } =
     useAction(LondonMoveAction);
-  const [selectedCity, setSelectedCity] = useState<string | undefined>(
+  const [selectedCity, setSelectedCity] = useState<Coordinates | undefined>(
     undefined,
   );
 
@@ -35,22 +39,20 @@ export function LondonMoveInterceptorModal({
   const options = useMemo(() => {
     if (moveData == null) return [];
 
-    const result: Array<{ key: string; text: string; value: string }> = [];
+    const result: Array<{ label: string; city: City }> = [];
 
     const start = grid.get(moveData.startingCity);
     if (start && start instanceof City) {
       result.push({
-        key: start.name(),
-        text: start.name(),
-        value: start.coordinates.serialize(),
+        label: "Source",
+        city: start,
       });
     }
     const end = grid.get(moveData.path[moveData.path.length - 1].endingStop);
     if (end && end instanceof City) {
       result.push({
-        key: end.name(),
-        text: end.name(),
-        value: end.coordinates.serialize(),
+        label: "Destination",
+        city: end,
       });
     }
 
@@ -62,19 +64,12 @@ export function LondonMoveInterceptorModal({
       return;
     }
     emitMoveAction({
-      city: Coordinates.unserialize(selectedCity),
+      city: selectedCity,
       ...moveData!,
     });
     clearMoveData();
     setSelectedCity(undefined);
   }, [emitMoveAction, clearMoveData, moveData, selectedCity]);
-
-  const onChange = useCallback(
-    (_: unknown, { value }: DropdownProps) => {
-      setSelectedCity(value as string | undefined);
-    },
-    [setSelectedCity],
-  );
 
   return (
     <Modal closeIcon open={moveData != null} onClose={clearMoveData}>
@@ -86,18 +81,60 @@ export function LondonMoveInterceptorModal({
         <p>
           The top good from the goods display will be moved to the city. If
           there are no goods left, a random cube will be drawn from the bag and
-          added to the goods display. This will make the action non-reversible.
+          added to the goods display.
         </p>
-        <Select placeholder="City" options={options} onChange={onChange} />
+        <div>
+          {options.map((option) => {
+            const onRoll = option.city.onRoll();
+            assert(onRoll.length === 1);
+            const goods = onRoll[0].goods;
+            let goodToAdd: Good | undefined;
+            for (let i = goods.length - 1; i >= 0; i--) {
+              const g = goods[i];
+              if (g !== null && g !== undefined) {
+                goodToAdd = g;
+                break;
+              }
+            }
+
+            return (
+              <div
+                key={option.label}
+                className={`${styles.cityOption} ${selectedCity && option.city.coordinates.equals(selectedCity) ? styles.selected : ""}`}
+                onClick={() => setSelectedCity(option.city.coordinates)}
+              >
+                <div>{option.label}</div>
+                <CityInfo city={option.city} />
+                <div>
+                  {goodToAdd !== undefined
+                    ? `Add a ${goodToString(goodToAdd)} good`
+                    : "Add a random good to goods growth"}
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </ModalContent>
       <ModalActions>
         <Button onClick={clearMoveData} disabled={isPending}>
           Cancel
         </Button>
-        <Button onClick={completeMove} disabled={isPending}>
+        <Button
+          onClick={completeMove}
+          disabled={isPending || selectedCity === undefined}
+        >
           Select City
         </Button>
       </ModalActions>
     </Modal>
   );
+}
+
+function CityInfo({ city }: { city: City }) {
+  const mapSettings = MapRegistry.singleton.get(useGameKey());
+  const grid = useMemo(() => {
+    return Grid.fromSpaces(mapSettings, [city], []);
+  }, [mapSettings]);
+
+  return <HexGrid grid={grid} />;
 }

--- a/src/maps/london/rules.tsx
+++ b/src/maps/london/rules.tsx
@@ -28,7 +28,7 @@ export function LondonRules() {
             have built.
           </p>
           <div style={{ marginBottom: "1em" }}>
-            <Table celled compact collapsing>
+            <Table celled compact collapsing unstackable>
               <TableHeader>
                 <TableRow>
                   <TableHeaderCell># Tiles</TableHeaderCell>


### PR DESCRIPTION
Shows the two cities that you're selecting between, labels them as source and destination, and clarifies the action (either which color cube will be added, or that a random cube will be drawn and added to goods growth).

<img width="922" alt="Screenshot 2025-06-07 at 18 22 26" src="https://github.com/user-attachments/assets/509e8567-a135-43b3-99b1-7d2ca0810a28" />

<img width="944" alt="Screenshot 2025-06-07 at 18 25 22" src="https://github.com/user-attachments/assets/7ae5d474-9677-4ba9-b1a7-09e08d4017db" />

On mobile the choices will stack for typical screen widths.
<img width="435" alt="Screenshot 2025-06-07 at 18 23 33" src="https://github.com/user-attachments/assets/5e825557-3556-478b-ad2e-7df09f061914" />
