### PR TITLE
[Scandinavia] Maybe fix ferries

### DIFF
--- a/src/maps/scandinavia/ferry.ts
+++ b/src/maps/scandinavia/ferry.ts
@@ -63,18 +63,11 @@ export class ScandinaviaMoveValidator extends MoveValidator {
     super.validatePartial(player, action);
 
     const numTeleports = action.path.filter(isTeleport).length;
-    if (player.selectedAction === Action.FERRY) {
+    if (player.selectedAction === Action.FERRY && !this.usedFerry) {
       assert(numTeleports <= 1, {
         invalidInput: "can only use the ferry once in a move",
       });
-      assert(!this.usedFerry.getOr(false), {
-        invalidInput: "can only use the ferry once per round",
-      });
-    } else {
-      assert(numTeleports <= 0, {
-        invalidInput: "cannot use a teleport without the ferry action",
-      });
-    }
+    } 
   }
 
   findRoutesToLocation(
@@ -82,6 +75,9 @@ export class ScandinaviaMoveValidator extends MoveValidator {
     fromCoordinates: Coordinates,
     toCoordinates: Coordinates,
   ): RouteInfo[] {
+    if(this.usedFerry.getOr(false)){
+      return super.findRoutesToLocation(player, fromCoordinates, toCoordinates);
+    }
     return super
       .findRoutesToLocation(player, fromCoordinates, toCoordinates)
       .concat(this.findTeleportRoutes(player, fromCoordinates, toCoordinates));

--- a/src/maps/scandinavia/ferry.ts
+++ b/src/maps/scandinavia/ferry.ts
@@ -63,7 +63,7 @@ export class ScandinaviaMoveValidator extends MoveValidator {
     super.validatePartial(player, action);
 
     const numTeleports = action.path.filter(isTeleport).length;
-    if (player.selectedAction === Action.FERRY && !this.usedFerry) {
+    if (player.selectedAction === Action.FERRY) {
       assert(numTeleports <= 1, {
         invalidInput: "can only use the ferry once in a move",
       });


### PR DESCRIPTION
Ok, so this was a bit tough to grasp initially but in general with current implementation of ferries one of the players in my game could not perform a regular delivery on second of his moves as the second assert here always considered his move a ferry action as it was fulfilling Action.FERRY in the conditional + also between two coastal cities which coincidentally had a valid land route:

`assert(!this.usedFerry.getOr(false), {
        invalidInput: "can only use the ferry once per round",
      });`

I then moved the check for it to encapsulating if statement and removed the assert from else as it either way will never get called in my understanding (_findTeleportRoutes()_ always returns [] for non ferry action).

The check for usage of ferries in previous turn is then indirectly moved to _findRoutesToLocation()._

Maybe there is a better solution but in my testing this has worked as intended and removed the issue mentioned in the beginning.