### PR TITLE
Finish implementation of notes in the front-end.

### DIFF
--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -6,7 +6,7 @@ const c = initContract();
 const Notes = z.object({
   notes: z.string(),
 });
-type Notes = z.infer<typeof Notes>;
+export type Notes = z.infer<typeof Notes>;
 
 export const notesContract = c.router({
   get: {

--- a/src/client/game/game_notes.tsx
+++ b/src/client/game/game_notes.tsx
@@ -1,0 +1,81 @@
+import React, { useCallback, useState } from "react";
+
+import { useGame } from "../services/game";
+import {
+  Button,
+  Header,
+  Modal,
+  ModalActions,
+  ModalContent,
+  TextArea,
+} from "semantic-ui-react";
+import { tsr } from "../services/client";
+import { handleError } from "../services/network";
+import { Notes } from "../../api/notes";
+
+function useNotes(gameId: number): Notes {
+  const { data } = tsr.notes.get.useSuspenseQuery({
+    queryKey: ["notes", gameId],
+    queryData: { params: { gameId } },
+  });
+
+  return data.body;
+}
+
+function useSetNotes(gameId: number, onSuccess: () => void) {
+  const { mutate, error, isPending } = tsr.notes.set.useMutation();
+  const validationError = handleError(isPending, error);
+
+  const setNotes = useCallback(
+    (body: Notes) => {
+      mutate(
+        { params: { gameId }, body: body },
+        {
+          onSuccess: () => onSuccess(),
+        },
+      );
+    },
+    [mutate, gameId],
+  );
+
+  return { setNotes, isPending, validationError };
+}
+
+export function GameNotesButton() {
+  const game = useGame();
+  const notes = useNotes(game.id);
+  const [open, setOpen] = useState<boolean>(!!notes.notes);
+  const [notesDraft, setNotesDraft] = useState<string>(notes.notes);
+  const { setNotes, isPending } = useSetNotes(game.id, () => setOpen(false));
+
+  return (
+    <>
+      <Modal closeIcon open={open} onClose={() => setOpen(false)}>
+        <Header>Game Notes</Header>
+        <ModalContent>
+          <TextArea
+            style={{ width: "100%", height: "8em" }}
+            value={notesDraft}
+            onChange={(_, data) => setNotesDraft(data.value as string)}
+          />
+          <p>
+            Notes written here are not visible to any other players. They will
+            automatically be shown when returning to this game.
+          </p>
+        </ModalContent>
+        <ModalActions>
+          <Button
+            primary
+            onClick={() => {
+              setNotes({ notes: notesDraft });
+            }}
+            disabled={isPending}
+          >
+            Save
+          </Button>
+        </ModalActions>
+      </Modal>
+      <Button onClick={() => setOpen(true)}>Game Notes</Button>
+    </>
+  );
+}

--- a/src/client/game/options.tsx
+++ b/src/client/game/options.tsx
@@ -12,6 +12,7 @@ import { useAbandon, useConcede, useGame, useKick } from "../services/game";
 import { useMe } from "../services/me";
 import * as styles from "./options.module.css";
 import { useState } from "react";
+import { GameNotesButton } from "./game_notes";
 
 export function GameOptions() {
   const game = useGame();
@@ -93,6 +94,12 @@ export function GameOptions() {
                   the current player.
                 </p>
               )}
+            </div>
+            <div className={styles.row}>
+              <div className={styles.buttonContainer}>
+                <GameNotesButton />
+              </div>
+              <p>Add notes for yourself for when you return to this game.</p>
             </div>
           </div>
         </AccordionContent>

--- a/src/server/game/dao.ts
+++ b/src/server/game/dao.ts
@@ -149,7 +149,7 @@ export class GameDao extends Model<
     assert(index >= 0, { unauthorized: "only players can set notes" });
     this.notes ??= [];
     this.notes[index] = notes;
-    this.changed("notes");
+    this.changed("notes", true);
   }
 }
 


### PR DESCRIPTION
I'd be open to a bunch of different places this could go, but for now I put a button down in game options to open up the notes modal, and notes will automatically show when returning to a game where you have saved notes.

![Screenshot 2025-06-20 at 10 04 44](https://github.com/user-attachments/assets/f0100abd-8183-4f19-b3d6-5c5c458d6c39)

![Screenshot 2025-06-20 at 10 04 32](https://github.com/user-attachments/assets/7425ce68-e6b5-47bc-81c2-3c15eb7a896e)

![Screenshot 2025-06-20 at 10 05 33](https://github.com/user-attachments/assets/3ea029ea-1707-4f16-a7fc-41d370f60984)

![Screenshot 2025-06-20 at 10 05 25](https://github.com/user-attachments/assets/d1a4faf8-b3d6-4e37-b90e-50378b6b69c0)
