### PR TITLE
Refactor intercity connections so that more than one per city pair can be supported.

### DIFF
--- a/src/client/grid/click_target.ts
+++ b/src/client/grid/click_target.ts
@@ -10,7 +10,6 @@ import {
   HeavyLiftingAction,
   HeavyLiftingData,
 } from "../../maps/heavy_cardboard/heavy_lifting";
-import { Coordinates } from "../../utils/coordinates";
 import { PromiseOr } from "../../utils/types";
 import { assertNever } from "../../utils/validate";
 import { useConfirm } from "../components/confirm";
@@ -55,7 +54,7 @@ type OnClickHandlerTuple =
 interface OnClickResponse {
   clickTargets: Set<ClickTarget>;
   onClick(space: Space, good?: Good): Promise<void>;
-  onClickInterCity(coordinates: Coordinates[]): void;
+  onClickInterCity(id: string): void;
 }
 
 function useClaim(on: OnClickRegister) {
@@ -181,7 +180,7 @@ export function useOnClick(
   };
 
   const onClickInterCity = useCallback(
-    (connect: Coordinates[]) => emitConnectCity({ connect }),
+    (id: string) => emitConnectCity({ id }),
     [emitConnectCity],
   );
 

--- a/src/client/grid/hex_grid.tsx
+++ b/src/client/grid/hex_grid.tsx
@@ -14,10 +14,7 @@ import { Rotation } from "../../engine/game/map_settings";
 import { Grid, Space } from "../../engine/map/grid";
 import { Track } from "../../engine/map/track";
 import { Good } from "../../engine/state/good";
-import {
-  interCityConnectionEquals,
-  OwnedInterCityConnection,
-} from "../../engine/state/inter_city_connection";
+import { OwnedInterCityConnection } from "../../engine/state/inter_city_connection";
 import { Direction } from "../../engine/state/tile";
 import { ViewRegistry } from "../../maps/view_registry";
 import { Coordinates } from "../../utils/coordinates";
@@ -46,7 +43,7 @@ interface HexGridProps {
   spaceToConfirm?: Space;
   onSpaceConfirm?: () => void;
   onClick?: (space: Space, good?: Good) => void;
-  onClickInterCity?: (connects: Coordinates[]) => void;
+  onClickInterCity?: (id: string) => void;
   highlightedSpaces?: Set<Coordinates>;
   highlightedTrack?: Track[];
   highlightedConnections?: OwnedInterCityConnection[];
@@ -324,8 +321,8 @@ export function HexGrid({
               {grid.connections.map((connection, index) => (
                 <InterCityConnectionRender
                   key={index}
-                  highlighted={highlightedConnections?.some((c) =>
-                    interCityConnectionEquals(connection, c),
+                  highlighted={highlightedConnections?.some(
+                    (c) => connection.id === c.id,
                   )}
                   clickTargets={clickTargetsNormalized}
                   onClick={onClickInterCity}

--- a/src/client/grid/inter_city_connection.tsx
+++ b/src/client/grid/inter_city_connection.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { Rotation } from "../../engine/game/map_settings";
 import { InterCityConnection } from "../../engine/state/inter_city_connection";
-import { Coordinates } from "../../utils/coordinates";
 import { coordinatesToCenter, movePointInDirection } from "../../utils/point";
 import { getPlayerColorCss } from "../components/player_color";
 import { Rotate } from "../components/rotation";
@@ -15,7 +14,7 @@ interface InterCityConnectionRenderProps {
   clickTargets: Set<ClickTarget>;
   highlighted?: boolean;
   rotation?: Rotation;
-  onClick?: (connects: Coordinates[]) => void;
+  onClick?: (id: string) => void;
 }
 
 export function InterCityConnectionRender({
@@ -40,7 +39,7 @@ export function InterCityConnectionRender({
     : "";
 
   const internalOnClick = useCallback(
-    () => onClick && onClick(connection.connects),
+    () => onClick && onClick(connection.id!),
     [...connection.connects],
   );
 

--- a/src/client/grid/move_good.ts
+++ b/src/client/grid/move_good.ts
@@ -7,7 +7,7 @@ import { Good } from "../../engine/state/good";
 import { PlayerData } from "../../engine/state/player";
 import { Coordinates } from "../../utils/coordinates";
 import { InvalidInputError } from "../../utils/error";
-import { arrayEqualsIgnoreOrder, peek } from "../../utils/functions";
+import { peek } from "../../utils/functions";
 import { useAction } from "../services/action";
 import { useTypedCallback } from "../utils/hooks";
 import {
@@ -195,10 +195,7 @@ function redirectPath(
           routeInfo.startingTrack.equals(previousRoute.startingTrack)
       : routeInfo.type === "connection"
         ? previousRoute.type === "connection" &&
-          arrayEqualsIgnoreOrder(
-            routeInfo.connection.connects,
-            previousRoute.connection.connects,
-          )
+          routeInfo.connection.id === previousRoute.connection.id
         : previousRoute.type === "teleport";
   });
   return newDatas[(previousRouteExitIndex + 1) % newDatas.length];

--- a/src/engine/build/urbanize.ts
+++ b/src/engine/build/urbanize.ts
@@ -7,7 +7,6 @@ import { Log } from "../game/log";
 import { AVAILABLE_CITIES, injectCurrentPlayer, injectGrid } from "../game/state";
 import { GridHelper } from "../map/grid_helper";
 import { Land } from "../map/location";
-import { Track } from "../map/track";
 import { Action } from "../state/action";
 import { toLetter } from "../state/city_group";
 import { SpaceType } from "../state/location_type";
@@ -65,8 +64,8 @@ export class UrbanizeAction implements ActionProcessor<UrbanizeData> {
 
     // Take ownership of connecting unowned track.
     for (const direction of allDirections) {
-      const connection = this.grid().connection(data.coordinates, direction);
-      if (!(connection instanceof Track) || connection.getOwner() != null) continue;
+      const connection = this.grid().getTrackConnection(data.coordinates, direction);
+      if (connection == null || connection.getOwner() != null) continue;
       if (this.grid().getRoute(connection).some((track) => track.isClaimable())) continue;
 
       this.gridHelper.setRouteOwner(connection, this.currentPlayer().color);

--- a/src/engine/build/validator.ts
+++ b/src/engine/build/validator.ts
@@ -158,8 +158,8 @@ export class Validator {
     if (exit === TOWN) {
       return [coordinates, exit];
     }
-    const neighbor = this.grid().connection(coordinates, exit);
-    if (!(neighbor instanceof Track)) {
+    const neighbor = this.grid().getTrackConnection(coordinates, exit);
+    if (neighbor == null) {
       return [coordinates, exit];
     }
     return this.grid().getEnd(neighbor, getOpposite(exit));
@@ -233,8 +233,8 @@ export class Validator {
     return newTracks.some((track) => {
       return track.exits.some((exit) => {
         if (exit == TOWN) return false;
-        const connection = this.grid().connection(space.coordinates, exit);
-        if (!(connection instanceof Track)) return false;
+        const connection = this.grid().getTrackConnection(space.coordinates, exit);
+        if (connection === undefined) return false;
         return connection.getOwner() != null && connection.getOwner() != playerColor;
       });
     });

--- a/src/engine/map/grid.ts
+++ b/src/engine/map/grid.ts
@@ -177,18 +177,10 @@ export class Grid {
     const isClaimableRoute = track.isClaimable() || track.wasClaimed();
     return tupleMap(track.getExits(), (exit) => {
       const otherExit = track.otherExit(exit);
-      let connects: boolean;
-      if (exit === TOWN) {
-        connects = true;
-      } else if (this.getNeighbor(track.coordinates, exit) instanceof City) {
-        connects = true;
-      } else if (
-        this.getTrackConnection(track.coordinates, exit) !== undefined
-      ) {
-        connects = true;
-      } else {
-        connects = false;
-      }
+      const connects =
+        exit === TOWN ||
+        this.getNeighbor(track.coordinates, exit) instanceof City ||
+        this.getTrackConnection(track.coordinates, exit) !== undefined;
       return {
         exit,
         dangles: !isClaimableRoute && !connects,

--- a/src/engine/map/grid_helper.ts
+++ b/src/engine/map/grid_helper.ts
@@ -3,10 +3,7 @@ import { deepEquals } from "../../utils/deep_equals";
 import { assert } from "../../utils/validate";
 import { injectState } from "../framework/execution_context";
 import { GRID, injectGrid, INTER_CITY_CONNECTIONS } from "../game/state";
-import {
-  InterCityConnection,
-  interCityConnectionEquals,
-} from "../state/inter_city_connection";
+import { InterCityConnection } from "../state/inter_city_connection";
 import { SpaceType } from "../state/location_type";
 import { PlayerColor } from "../state/player";
 import { MutableSpaceData, SpaceData } from "../state/space";
@@ -61,9 +58,7 @@ export class GridHelper {
     connection: InterCityConnection,
   ): void {
     this.interCityConnections.update((connections) => {
-      const matching = connections.find((c) =>
-        interCityConnectionEquals(connection, c),
-      )!;
+      const matching = connections.find((c) => c.id === connection.id)!;
       matching.owner = { color: owner };
     });
   }

--- a/src/engine/state/inter_city_connection.ts
+++ b/src/engine/state/inter_city_connection.ts
@@ -1,9 +1,9 @@
 import z from "zod";
 import { CoordinatesZod } from "../../utils/coordinates";
-import { arrayEqualsIgnoreOrder } from "../../utils/functions";
 import { PlayerColorZod } from "./player";
 
 export const InterCityConnection = z.object({
+  id: z.string(),
   connects: CoordinatesZod.array(),
   cost: z.number(),
   // No owner means the connection isn't built. An owner but no color means it's built but unowned.
@@ -11,13 +11,7 @@ export const InterCityConnection = z.object({
 });
 export type InterCityConnection = z.infer<typeof InterCityConnection>;
 
-export type OwnedInterCityConnection = Required<InterCityConnection>;
-
-export function interCityConnectionEquals(
-  first?: InterCityConnection | OwnedInterCityConnection,
-  second?: InterCityConnection | OwnedInterCityConnection,
-) {
-  if (first == null && second == null) return true;
-  if (first == null || second == null) return false;
-  return arrayEqualsIgnoreOrder(first.connects, second.connects);
-}
+export const OwnedInterCityConnection = InterCityConnection.required({
+  owner: true,
+});
+export type OwnedInterCityConnection = z.infer<typeof OwnedInterCityConnection>;

--- a/src/maps/factory.ts
+++ b/src/maps/factory.ts
@@ -150,7 +150,8 @@ export function interCityConnections(
     }),
   );
   return connections.map(
-    (spec): InterCityConnection => ({
+    (spec, idx): InterCityConnection => ({
+      id: "" + (idx + 1),
       connects: [cities.get(spec.connects[0])!, cities.get(spec.connects[1])!],
       cost: spec.cost ?? 2,
       owner: undefined,

--- a/src/maps/heavy_cardboard/heavy_lifting.ts
+++ b/src/maps/heavy_cardboard/heavy_lifting.ts
@@ -11,7 +11,7 @@ import { City } from "../../engine/map/city";
 import { getOpposite } from "../../engine/map/direction";
 import { GridHelper } from "../../engine/map/grid_helper";
 import { Land } from "../../engine/map/location";
-import { TOWN, Track } from "../../engine/map/track";
+import { TOWN } from "../../engine/map/track";
 import { MoveHelper } from "../../engine/move/helper";
 import { MovePhase } from "../../engine/move/phase";
 import { AllowedActions } from "../../engine/select_action/allowed_actions";
@@ -136,11 +136,11 @@ export class HeavyLiftingAction implements ActionProcessor<HeavyLiftingData> {
       );
     } else {
       return allDirections.some((direction) => {
-        const track = this.grid().connection(
+        const track = this.grid().getTrackConnection(
           startingCity.coordinates,
           direction,
         );
-        if (!(track instanceof Track)) return false;
+        if (track === undefined) return false;
         if (track.getOwner() !== this.currentPlayer().color) return false;
         const [endTrack, exit] = this.grid().getEnd(
           track,

--- a/src/maps/india-steam-brothers/goods_growth.ts
+++ b/src/maps/india-steam-brothers/goods_growth.ts
@@ -4,7 +4,7 @@ import { inject } from "../../engine/framework/execution_context";
 import { GoodsHelper } from "../../engine/goods_growth/helper";
 import { City } from "../../engine/map/city";
 import { calculateTrackInfo } from "../../engine/map/location";
-import { TOWN, Track } from "../../engine/map/track";
+import { TOWN } from "../../engine/map/track";
 import { PlayerColor } from "../../engine/state/player";
 import { allDirections } from "../../engine/state/tile";
 import { Coordinates } from "../../utils/coordinates";
@@ -26,15 +26,15 @@ export class IndiaSteamBrothersBuildAction extends BuildAction {
       .filter((track) => track.owner === currentColor)
       .flatMap(({ exits }) => exits)
       .filter((exit) => exit !== TOWN)
-      .map((exit) => this.grid().connection(data.coordinates, exit))
-      .filter((connection) => connection instanceof City)
+      .map((exit) => this.grid().getNeighbor(data.coordinates, exit))
+      .filter((neighbor) => neighbor instanceof City)
       .filter((city) => {
         for (const direction of allDirections) {
-          const cityConnection = this.grid().connection(
+          const cityConnection = this.grid().getTrackConnection(
             city.coordinates,
             direction,
           );
-          if (!(cityConnection instanceof Track)) continue;
+          if (cityConnection == null) continue;
           if (cityConnection.getOwner() === currentColor) return false;
         }
         return true;
@@ -60,8 +60,8 @@ export class IndiaSteamBrothersUrbanizeAction extends UrbanizeAction {
     const connectedPlayers = new Set<PlayerColor | undefined>();
 
     for (const direction of allDirections) {
-      const connection = this.grid().connection(coordinates, direction);
-      if (!(connection instanceof Track)) continue;
+      const connection = this.grid().getTrackConnection(coordinates, direction);
+      if (connection == null) continue;
       connectedPlayers.add(connection.getOwner());
     }
 

--- a/src/maps/montreal_metro/government_track.ts
+++ b/src/maps/montreal_metro/government_track.ts
@@ -10,7 +10,7 @@ import { ROUND } from "../../engine/game/round";
 import { City } from "../../engine/map/city";
 import { calculateTrackInfo, Land } from "../../engine/map/location";
 import { isTownTile } from "../../engine/map/tile";
-import { TOWN, Track, TrackInfo } from "../../engine/map/track";
+import { TOWN, TrackInfo } from "../../engine/map/track";
 import { Phase } from "../../engine/state/phase";
 import { PlayerColor, PlayerColorZod } from "../../engine/state/player";
 import { allDirections, Direction } from "../../engine/state/tile";
@@ -81,17 +81,17 @@ export class MontrealMetroBuildAction extends BuildAction {
     const trackIsContiguous = (track: TrackInfo) =>
       track.exits.some((exit) => {
         if (exit === TOWN) return false;
-        const connection = this.grid().connection(data.coordinates, exit);
-        if (connection instanceof Track) {
+        if (this.grid().getTrackConnection(data.coordinates, exit) != null) {
           return true;
         }
-        if (!(connection instanceof City)) {
+        const neighbor = this.grid().getNeighbor(data.coordinates, exit);
+        if (!(neighbor instanceof City)) {
           return false;
         }
         return allDirections.some((direction) => {
           return (
-            this.grid().connection(connection.coordinates, direction) instanceof
-            Track
+            this.grid().getTrackConnection(neighbor.coordinates, direction) !=
+            null
           );
         });
       });
@@ -118,8 +118,8 @@ export class MontrealMetroBuildAction extends BuildAction {
     if (trackInfo.length !== 1) return false;
     return trackInfo[0].exits.some((exit) => {
       if (exit === TOWN) return false;
-      const connection = this.grid().connection(data.coordinates, exit);
-      return connection instanceof Track;
+      const connection = this.grid().getTrackConnection(data.coordinates, exit);
+      return connection != null;
     });
   }
 
@@ -149,7 +149,13 @@ export class MontrealMetroBuildAction extends BuildAction {
       }
       return track.exits.every((exit) => {
         if (exit === TOWN) return true;
-        return this.grid().connection(data.coordinates, exit) != null;
+        if (this.grid().getTrackConnection(data.coordinates, exit) != null) {
+          return true;
+        }
+        if (this.grid().getNeighbor(data.coordinates, exit) instanceof City) {
+          return true;
+        }
+        return false;
       });
     });
     return !isComplete;

--- a/src/maps/moon/builds.ts
+++ b/src/maps/moon/builds.ts
@@ -3,7 +3,7 @@ import { BuilderHelper } from "../../engine/build/helper";
 import { City } from "../../engine/map/city";
 import { calculateTrackInfo } from "../../engine/map/location";
 import { isTownTile } from "../../engine/map/tile";
-import { TOWN, Track, TrackInfo } from "../../engine/map/track";
+import { TOWN, TrackInfo } from "../../engine/map/track";
 import { Action } from "../../engine/state/action";
 import { allDirections } from "../../engine/state/tile";
 import { assert } from "../../utils/validate";
@@ -22,13 +22,16 @@ export class MoonBuildAction extends BuildAction {
       track.exits.some((exit) => {
         if (exit === TOWN) return false;
 
-        const neighbor = this.grid().connection(data.coordinates, exit);
-        if (neighbor instanceof Track) return true;
+        if (this.grid().getTrackConnection(data.coordinates, exit) != null) {
+          return true;
+        }
+        const neighbor = this.grid().getNeighbor(data.coordinates, exit);
         if (!(neighbor instanceof City)) return false;
         if (neighbor.name() === "Moon Base") return true;
         return allDirections.some(
           (direction) =>
-            this.grid().connection(neighbor.coordinates, direction) != null,
+            this.grid().getTrackConnection(neighbor.coordinates, direction) !=
+            null,
         );
       });
     const allConnected = isTownTile(data.tileType)

--- a/src/maps/moon/day_night.ts
+++ b/src/maps/moon/day_night.ts
@@ -77,7 +77,8 @@ export class MoonGoodsGrowthPhase extends GoodsGrowthPhase {
     }
     const connected = allDirections.some(
       (direction) =>
-        this.actualGrid().connection(city.coordinates, direction) != null,
+        this.actualGrid().getTrackConnection(city.coordinates, direction) !=
+        null,
     );
     if (!connected) return true;
 

--- a/src/migrations/20250621214034_connection_ids.ts
+++ b/src/migrations/20250621214034_connection_ids.ts
@@ -1,0 +1,70 @@
+import { QueryTypes } from "@sequelize/core";
+import type { Migration } from "../scripts/migrations";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  const [rows, _] = await queryInterface.sequelize.query(
+    `SELECT "id","gameData" FROM "Games"`,
+  );
+  for (const rowObj of rows) {
+    const row = rowObj as { id: string; gameData: string };
+    const id: string = row["id"];
+    const gameData = JSON.parse(row["gameData"]);
+    let dirty = false;
+    if (
+      gameData &&
+      gameData.gameData &&
+      gameData.gameData.interCityConnections
+    ) {
+      const connections = gameData.gameData.interCityConnections;
+      for (let i = 0; i < connections.length; i++) {
+        connections[i]["id"] = "" + (i + 1);
+        dirty = true;
+      }
+    }
+
+    if (dirty) {
+      await queryInterface.sequelize.query(
+        `UPDATE "Games" SET "gameData"=? WHERE "id"=?`,
+        {
+          replacements: [JSON.stringify(gameData), id],
+          type: QueryTypes.UPDATE,
+        },
+      );
+    }
+  }
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  const [rows, _] = await queryInterface.sequelize.query(
+    `SELECT "id","gameData" FROM "Games"`,
+  );
+  for (const rowObj of rows) {
+    const row = rowObj as { id: string; gameData: string };
+    const id: string = row["id"];
+    const gameData = JSON.parse(row["gameData"]);
+    let dirty = false;
+    if (
+      gameData &&
+      gameData.gameData &&
+      gameData.gameData.interCityConnections
+    ) {
+      const connections = gameData.gameData.interCityConnections;
+      for (let i = 0; i < connections.length; i++) {
+        if (connections[i]["id"]) {
+          delete connections[i]["id"];
+          dirty = true;
+        }
+      }
+    }
+
+    if (dirty) {
+      await queryInterface.sequelize.query(
+        `UPDATE "Games" SET "gameData"=? WHERE "id"=?`,
+        {
+          replacements: [JSON.stringify(gameData), id],
+          type: QueryTypes.UPDATE,
+        },
+      );
+    }
+  }
+};


### PR DESCRIPTION
This is a somewhat significant refactor that warrants a close look to make sure I didn't break anything. The goal here is to change an underlying assumption that there can be exactly 1 intercity connection between two coordinates. In some maps like Honeybee Hivemind, there can be 2 or 3 intercity connections available between two cities. Breaking down this assumption also enables the use of intercity connections for more complicated "ferry links" such as on Denmark or Portugal.

Since which cities are being connected is no longer sufficient to indicate which intercity connection is being built, this code is refactored to use an `id` on intercity connections. This necessitates a forklift of existing gameData to add this id so that an `id` on each intercity connection is available for existing games in progress.

As a bit more of a concrete indicator of where I'm going with this, here's a screenshot from Denmark WIP. In this case, multiple players can build the "intercity connections". When selecting a route during move goods, users can utilize those intercity connections the way you'd expect and can toggle through them to select the desired owned intercity connection.

<img width="912" alt="Screenshot 2025-06-21 at 22 15 39" src="https://github.com/user-attachments/assets/059465be-750f-45c7-a00d-f34a927bb33a" />
