### PR TITLE
Move action naming and description into an injectable ActionNamingProvider

### DIFF
--- a/src/client/auto_action/form.tsx
+++ b/src/client/auto_action/form.tsx
@@ -2,7 +2,7 @@ import { MouseEvent, useCallback, useState } from "react";
 import { GameStatus } from "../../api/game";
 import { inject } from "../../engine/framework/execution_context";
 import { AllowedActions } from "../../engine/select_action/allowed_actions";
-import { Action, getSelectedActionString } from "../../engine/state/action";
+import { Action, ActionNamingProvider } from "../../engine/state/action";
 import { AutoAction } from "../../engine/state/auto_action";
 import { canEditGame, useGame } from "../services/game";
 import { useMe } from "../services/me";
@@ -11,25 +11,25 @@ import {
   useSemanticSelectState,
   useSemanticUiCheckboxState,
 } from "../utils/form_state";
-import { useInject } from "../utils/injection_context";
+import { useInject, useInjected } from "../utils/injection_context";
 import * as styles from "./form.module.css";
 import { useAutoAction, useSetAutoAction } from "./hooks";
 import {
   Accordion,
   AccordionContent,
   AccordionTitle,
+  Button,
+  Dropdown,
   Form,
   FormCheckbox,
   FormField,
   FormGroup,
+  Icon,
+  Input,
   Menu,
   MenuItem,
   Popup,
-  Icon,
-  Input,
-  Button,
   Radio,
-  Dropdown,
 } from "semantic-ui-react";
 
 export function AutoActionForm() {
@@ -71,6 +71,7 @@ function InternalAutoActionForm({
   expanded,
   setExpanded,
 }: InternalAutoActionFormProps) {
+  const actionNamingProvider = useInjected(ActionNamingProvider);
   const availableActions = useInject(
     () => inject(AllowedActions).getActions(),
     [],
@@ -316,7 +317,7 @@ function InternalAutoActionForm({
                         return {
                           key: action,
                           value: action,
-                          text: getSelectedActionString(action),
+                          text: actionNamingProvider.getActionString(action),
                         };
                       })}
                     />

--- a/src/client/game/action_summary.tsx
+++ b/src/client/game/action_summary.tsx
@@ -6,10 +6,8 @@ import {
   FormField,
   FormGroup,
   FormSelect,
-  Icon,
 } from "semantic-ui-react";
 import { BuildAction } from "../../engine/build/build";
-import { DoneAction } from "../../engine/build/done";
 import { BuilderHelper } from "../../engine/build/helper";
 import { inject, injectState } from "../../engine/framework/execution_context";
 import { PHASE } from "../../engine/game/phase";
@@ -35,7 +33,6 @@ import {
 } from "../../maps/st-lucia/bidding";
 import { iterate } from "../../utils/functions";
 import { assertNever } from "../../utils/validate";
-import { useConfirm } from "../components/confirm";
 import { Username } from "../components/username";
 import { useAction, useEmptyAction } from "../services/action";
 import {
@@ -46,6 +43,7 @@ import {
 } from "../utils/injection_context";
 import { ManualGoodsGrowth } from "./india-steam-brothers/goods_growth";
 import { MoveGoods } from "./move_goods_action_summary";
+import { Build } from "./build_action_summary";
 
 const PASS_ACTION = "Pass" as const;
 type PassActionString = typeof PASS_ACTION;
@@ -520,53 +518,4 @@ function GovernmentBuild() {
   }
 
   return <div>You can build {buildsRemaining} more government track.</div>;
-}
-
-function Build() {
-  const { emit: emitPass, canEmit, canEmitUserId } = useEmptyAction(DoneAction);
-  const confirm = useConfirm();
-  const [buildsRemaining, canUrbanize] = useInject(() => {
-    const helper = inject(BuilderHelper);
-    if (!canEmit) return [undefined, undefined];
-    return [helper.buildsRemaining(), helper.canUrbanize()];
-  }, [canEmit]);
-
-  const emitPassClick = useCallback(() => {
-    if (!canUrbanize) {
-      emitPass();
-      return;
-    }
-    confirm(
-      "You still have an urbanize available, are you sure you are done building?",
-    ).then((stillPass) => {
-      if (stillPass) {
-        emitPass();
-      }
-    });
-  }, [emitPass, canUrbanize]);
-
-  if (canEmitUserId == null) {
-    return <></>;
-  }
-
-  if (!canEmit) {
-    return (
-      <GenericMessage>
-        <Username userId={canEmitUserId} /> must build.
-      </GenericMessage>
-    );
-  }
-
-  return (
-    <div>
-      <p>
-        You can build {buildsRemaining} more track
-        {canUrbanize && " and urbanize"}.
-      </p>
-      <Button icon labelPosition="left" color="green" onClick={emitPassClick}>
-        <Icon name="check" />
-        Done Building
-      </Button>
-    </div>
-  );
 }

--- a/src/client/game/build_action_summary.tsx
+++ b/src/client/game/build_action_summary.tsx
@@ -1,0 +1,59 @@
+import { useEmptyAction } from "../services/action";
+import { DoneAction } from "../../engine/build/done";
+import { useConfirm } from "../components/confirm";
+import { useInject } from "../utils/injection_context";
+import { inject } from "../../engine/framework/execution_context";
+import { BuilderHelper } from "../../engine/build/helper";
+import { useCallback } from "react";
+import { Username } from "../components/username";
+import { Button, Icon } from "semantic-ui-react";
+import { GenericMessage } from "./action_summary";
+
+export function Build() {
+  const { emit: emitPass, canEmit, canEmitUserId } = useEmptyAction(DoneAction);
+  const confirm = useConfirm();
+  const [buildsRemaining, canUrbanize] = useInject(() => {
+    const helper = inject(BuilderHelper);
+    if (!canEmit) return [undefined, undefined];
+    return [helper.buildsRemaining(), helper.canUrbanize()];
+  }, [canEmit]);
+
+  const emitPassClick = useCallback(() => {
+    if (!canUrbanize) {
+      emitPass();
+      return;
+    }
+    confirm(
+      "You still have an urbanize available, are you sure you are done building?",
+    ).then((stillPass) => {
+      if (stillPass) {
+        emitPass();
+      }
+    });
+  }, [emitPass, canUrbanize]);
+
+  if (canEmitUserId == null) {
+    return <></>;
+  }
+
+  if (!canEmit) {
+    return (
+      <GenericMessage>
+        <Username userId={canEmitUserId} /> must build.
+      </GenericMessage>
+    );
+  }
+
+  return (
+    <div>
+      <p>
+        You can build {buildsRemaining} more track
+        {canUrbanize && " and urbanize"}.
+      </p>
+      <Button icon labelPosition="left" color="green" onClick={emitPassClick}>
+        <Icon name="check" />
+        Done Building
+      </Button>
+    </div>
+  );
+}

--- a/src/client/game/player_stats.tsx
+++ b/src/client/game/player_stats.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../engine/game/state";
 import { ProfitHelper } from "../../engine/income_and_expenses/helper";
 import { MoveHelper } from "../../engine/move/helper";
-import { getSelectedActionString } from "../../engine/state/action";
+import { ActionNamingProvider } from "../../engine/state/action";
 import { PlayerColor, PlayerData } from "../../engine/state/player";
 import { countryName } from "../../maps/cyprus/roles";
 import { CyprusMapSettings } from "../../maps/cyprus/settings";
@@ -29,8 +29,8 @@ import { LoginButton } from "./login_button";
 import * as styles from "./player_stats.module.css";
 import {
   Accordion,
-  AccordionTitle,
   AccordionContent,
+  AccordionTitle,
   Icon,
   Menu,
   MenuItem,
@@ -156,7 +156,8 @@ const actionColumn = {
 };
 
 function ActionCell({ player }: PlayerStatColumnProps) {
-  return <>{getSelectedActionString(player.selectedAction)}</>;
+  const actionNamingProvider = useInjected(ActionNamingProvider);
+  return <>{actionNamingProvider.getActionString(player.selectedAction)}</>;
 }
 
 const moneyColumn = {

--- a/src/client/game/special_action_table.tsx
+++ b/src/client/game/special_action_table.tsx
@@ -3,10 +3,8 @@ import { GameStatus } from "../../api/game";
 import { injectPlayerAction } from "../../engine/game/state";
 import { AllowedActions } from "../../engine/select_action/allowed_actions";
 import { SelectAction as ActionSelectionSelectAction } from "../../engine/select_action/select";
-import { Action, getSelectedActionString } from "../../engine/state/action";
+import { Action, ActionNamingProvider } from "../../engine/state/action";
 import { ViewRegistry } from "../../maps/view_registry";
-import { MapViewSettings } from "../../maps/view_settings";
-import { assertNever } from "../../utils/validate";
 import { MaybeTooltip } from "../components/maybe_tooltip";
 import { Username } from "../components/username";
 import { useAction } from "../services/action";
@@ -37,6 +35,7 @@ function SpecialAction({ action }: { action: Action }) {
   const { emit, canEmit, isPending } = useAction(ActionSelectionSelectAction);
   const allowed = useInjected(AllowedActions);
   const player = useInject(() => injectPlayerAction(action)(), [action]);
+  const actionNamingProvider = useInjected(ActionNamingProvider);
 
   const isClickable = canEmit && player == null && !isPending;
   const disabledReason =
@@ -62,9 +61,11 @@ function SpecialAction({ action }: { action: Action }) {
   return (
     <MaybeTooltip tooltip={disabledReason}>
       <div className={className} onClick={chooseAction}>
-        <div className={styles.name}>{getSelectedActionString(action)}</div>
+        <div className={styles.name}>
+          {actionNamingProvider.getActionString(action)}
+        </div>
         <div className={styles.description}>
-          {getSelectedActionDescription(action, mapSettings)}
+          {actionNamingProvider.getActionDescription(action)}
         </div>
         <div>
           <PlayerCircle
@@ -85,64 +86,4 @@ function SpecialAction({ action }: { action: Action }) {
       </div>
     </MaybeTooltip>
   );
-}
-
-function getSelectedActionDescription(
-  action: Action,
-  mapSettings: MapViewSettings,
-): string {
-  if (mapSettings.getActionDescription) {
-    const description = mapSettings.getActionDescription(action);
-    if (description) {
-      return description;
-    }
-  }
-
-  switch (action) {
-    case Action.ENGINEER:
-      return "Build an additional track during the Building step.";
-    case Action.FIRST_BUILD:
-      return "Go first during the Building step.";
-    case Action.FIRST_MOVE:
-      return "Go first during the Move Goods step.";
-    case Action.LOCOMOTIVE:
-      return "Immediately, increase your locomotive by one.";
-    case Action.PRODUCTION:
-      return "Before the Goods Growth step, draw two cubes and place them on the Goods Growth chart";
-    case Action.TURN_ORDER_PASS:
-      return "Next auction, pass without dropping out of the bidding.";
-    case Action.URBANIZATION:
-      return "Place a new city on any town during the build step.";
-    case Action.REPOPULATION:
-      return "Immediately, draw three cubes from the bag and place one on any station.";
-    case Action.DEURBANIZATION:
-      return "Before the Move Goods step, remove a goods cube of your choice from the map.";
-    case Action.WTE_PLANT_OPERATOR:
-      return "After the Move Goods step, take all black cubes from the WTE Plant space. Each cube is worth 2 points.";
-
-    case Action.LAST_BUILD:
-      return "Go last during the Building step.";
-    case Action.LAST_MOVE:
-      return "Go last during the Moving step.";
-    case Action.SLOW_ENGINEER:
-      return "Build one less track during the Building step.";
-    case Action.LAST_PLAYER:
-      return "Next auction, you must pass when it is your turn.";
-    case Action.HIGH_COSTS:
-      return "Each tile you build this turn costs an additional $4.";
-    case Action.ONE_MOVE:
-      return "Skip one of your move goods actions.";
-    case Action.COMMONWEALTH:
-      return "Reduces the cost of one $10 buid to $7.";
-    case Action.LOW_GRAVITATION:
-      return "Allows you to use other's links as if they are your own for both moves.";
-    case Action.HEAVY_LIFTING:
-      return "Allows you to move goods across open land. See rules for more information.";
-    case Action.PROTECTION:
-      return "Allows you to move black cubes from towns during the Move Goods step.";
-    case Action.FERRY:
-      return "Allows you to move one good across water. See rules for more information.";
-    default:
-      assertNever(action);
-  }
 }

--- a/src/engine/select_action/select.ts
+++ b/src/engine/select_action/select.ts
@@ -5,7 +5,7 @@ import { ActionProcessor } from "../game/action";
 import { Log } from "../game/log";
 import { PlayerHelper } from "../game/player";
 import { injectCurrentPlayer } from "../game/state";
-import { Action, getSelectedActionString } from "../state/action";
+import { Action, ActionNamingProvider } from "../state/action";
 import { AllowedActions } from "./allowed_actions";
 
 export const SelectData = z.object({
@@ -20,6 +20,7 @@ export class SelectAction implements ActionProcessor<SelectData> {
   protected readonly helper = inject(PlayerHelper);
   protected readonly log = inject(Log);
   private readonly actions = inject(AllowedActions);
+  private readonly actionNamingProvider = inject(ActionNamingProvider);
 
   readonly assertInput = SelectData.parse;
 
@@ -44,7 +45,9 @@ export class SelectAction implements ActionProcessor<SelectData> {
     if (action === Action.LOCOMOTIVE) {
       this.applyLocomotive();
     }
-    this.log.currentPlayer(`selected ${getSelectedActionString(action)}`);
+    this.log.currentPlayer(
+      `selected ${this.actionNamingProvider.getActionString(action)}`,
+    );
     return true;
   }
 }

--- a/src/engine/state/action.ts
+++ b/src/engine/state/action.ts
@@ -45,53 +45,105 @@ export enum Action {
 
 export const ActionZod = z.nativeEnum(Action);
 
-export function getSelectedActionString(action?: Action) {
-  switch (action) {
-    case undefined:
-      return "";
-    case Action.LOCOMOTIVE:
-      return "Locomotive";
-    case Action.FIRST_BUILD:
-      return "First Build";
-    case Action.FIRST_MOVE:
-      return "First Move";
-    case Action.ENGINEER:
-      return "Engineer";
-    case Action.TURN_ORDER_PASS:
-      return "Turn Order Pass";
-    case Action.URBANIZATION:
-      return "Urbanization";
-    case Action.PRODUCTION:
-      return "Production";
-    case Action.REPOPULATION:
-      return "Repopulation";
-    case Action.DEURBANIZATION:
-      return "Deurbanization";
-    case Action.WTE_PLANT_OPERATOR:
-      return "WTE Plant Operator";
-    case Action.LAST_BUILD:
-      return "Last Build";
-    case Action.LAST_MOVE:
-      return "Last Move";
-    case Action.SLOW_ENGINEER:
-      return "Slow Engineer";
-    case Action.LAST_PLAYER:
-      return "Last Player";
-    case Action.HIGH_COSTS:
-      return "High Costs";
-    case Action.ONE_MOVE:
-      return "One Move";
-    case Action.COMMONWEALTH:
-      return "Commonwealth";
-    case Action.LOW_GRAVITATION:
-      return "Low Gravitation";
-    case Action.HEAVY_LIFTING:
-      return "Heavy Lifting";
-    case Action.PROTECTION:
-      return "Protection";
-    case Action.FERRY:
-      return "Ferry";
-    default:
-      assertNever(action);
+export class ActionNamingProvider {
+  getActionString(action?: Action): string {
+    switch (action) {
+      case undefined:
+        return "";
+      case Action.LOCOMOTIVE:
+        return "Locomotive";
+      case Action.FIRST_BUILD:
+        return "First Build";
+      case Action.FIRST_MOVE:
+        return "First Move";
+      case Action.ENGINEER:
+        return "Engineer";
+      case Action.TURN_ORDER_PASS:
+        return "Turn Order Pass";
+      case Action.URBANIZATION:
+        return "Urbanization";
+      case Action.PRODUCTION:
+        return "Production";
+      case Action.REPOPULATION:
+        return "Repopulation";
+      case Action.DEURBANIZATION:
+        return "Deurbanization";
+      case Action.WTE_PLANT_OPERATOR:
+        return "WTE Plant Operator";
+      case Action.LAST_BUILD:
+        return "Last Build";
+      case Action.LAST_MOVE:
+        return "Last Move";
+      case Action.SLOW_ENGINEER:
+        return "Slow Engineer";
+      case Action.LAST_PLAYER:
+        return "Last Player";
+      case Action.HIGH_COSTS:
+        return "High Costs";
+      case Action.ONE_MOVE:
+        return "One Move";
+      case Action.COMMONWEALTH:
+        return "Commonwealth";
+      case Action.LOW_GRAVITATION:
+        return "Low Gravitation";
+      case Action.HEAVY_LIFTING:
+        return "Heavy Lifting";
+      case Action.PROTECTION:
+        return "Protection";
+      case Action.FERRY:
+        return "Ferry";
+      default:
+        assertNever(action);
+    }
+  }
+
+  getActionDescription(action: Action): string {
+    switch (action) {
+      case Action.ENGINEER:
+        return "Build an additional track during the Building step.";
+      case Action.FIRST_BUILD:
+        return "Go first during the Building step.";
+      case Action.FIRST_MOVE:
+        return "Go first during the Move Goods step.";
+      case Action.LOCOMOTIVE:
+        return "Immediately, increase your locomotive by one.";
+      case Action.PRODUCTION:
+        return "Before the Goods Growth step, draw two cubes and place them on the Goods Growth chart";
+      case Action.TURN_ORDER_PASS:
+        return "Next auction, pass without dropping out of the bidding.";
+      case Action.URBANIZATION:
+        return "Place a new city on any town during the build step.";
+      case Action.REPOPULATION:
+        return "Immediately, draw three cubes from the bag and place one on any station.";
+      case Action.DEURBANIZATION:
+        return "Before the Move Goods step, remove a goods cube of your choice from the map.";
+      case Action.WTE_PLANT_OPERATOR:
+        return "After the Move Goods step, take all black cubes from the WTE Plant space. Each cube is worth 2 points.";
+
+      case Action.LAST_BUILD:
+        return "Go last during the Building step.";
+      case Action.LAST_MOVE:
+        return "Go last during the Moving step.";
+      case Action.SLOW_ENGINEER:
+        return "Build one less track during the Building step.";
+      case Action.LAST_PLAYER:
+        return "Next auction, you must pass when it is your turn.";
+      case Action.HIGH_COSTS:
+        return "Each tile you build this turn costs an additional $4.";
+      case Action.ONE_MOVE:
+        return "Skip one of your move goods actions.";
+      case Action.COMMONWEALTH:
+        return "Reduces the cost of one $10 buid to $7.";
+      case Action.LOW_GRAVITATION:
+        return "Allows you to use other's links as if they are your own for both moves.";
+      case Action.HEAVY_LIFTING:
+        return "Allows you to move goods across open land. See rules for more information.";
+      case Action.PROTECTION:
+        return "Allows you to move black cubes from towns during the Move Goods step.";
+      case Action.FERRY:
+        return "Allows you to move one good across water. See rules for more information.";
+      default:
+        assertNever(action);
+    }
   }
 }

--- a/src/maps/australia/actions.ts
+++ b/src/maps/australia/actions.ts
@@ -1,0 +1,12 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class AustraliaActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.URBANIZATION) {
+      return "Place a new city on any town during the build step, but it uses one of your builds.";
+    } else if (action === Action.ENGINEER) {
+      return "Build an additional track during the Building step, and the most expensive build is free.";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/australia/settings.ts
+++ b/src/maps/australia/settings.ts
@@ -6,6 +6,7 @@ import { UrbanizationUsesBuildModule } from "../../modules/urbanization_uses_bui
 import { map } from "./grid";
 import { AustraliaMoveAction } from "./perth";
 import { AustraliaStarter } from "./starter";
+import { AustraliaActionNamingProvider } from "./actions";
 
 export class AustraliaMapSettings implements MapSettings {
   readonly key = GameKey.AUSTRALIA;
@@ -16,7 +17,11 @@ export class AustraliaMapSettings implements MapSettings {
   readonly stage = ReleaseStage.ALPHA;
 
   getOverrides() {
-    return [AustraliaStarter, AustraliaMoveAction];
+    return [
+      AustraliaStarter,
+      AustraliaMoveAction,
+      AustraliaActionNamingProvider,
+    ];
   }
 
   getModules(): Array<Module> {

--- a/src/maps/australia/view_settings.ts
+++ b/src/maps/australia/view_settings.ts
@@ -1,4 +1,3 @@
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { AustraliaRules } from "./rules";
 import { AustraliaMapSettings } from "./settings";
@@ -8,12 +7,4 @@ export class AustraliaViewSettings
   implements MapViewSettings
 {
   getMapRules = AustraliaRules;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action === Action.URBANIZATION) {
-      return "Place a new city on any town during the build step, but it uses one of your builds.";
-    } else if (action === Action.ENGINEER) {
-      return "Build an additional track during the Building step, and the most expensive build is free.";
-    }
-  }
 }

--- a/src/maps/disco/actions.ts
+++ b/src/maps/disco/actions.ts
@@ -1,0 +1,10 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class DiscoActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.PRODUCTION) {
+      return "Draw two cubes and place them in one city after the move goods step.";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/disco/settings.ts
+++ b/src/maps/disco/settings.ts
@@ -13,6 +13,7 @@ import {
   DiscoProductionPhase,
 } from "./production";
 import { DiscoStarter } from "./starter";
+import { DiscoActionNamingProvider } from "./actions";
 
 export class DiscoInfernoMapSettings implements MapSettings {
   static readonly key = GameKey.DISCO_INFERNO;
@@ -33,6 +34,7 @@ export class DiscoInfernoMapSettings implements MapSettings {
       DiscoMoveHelper,
       DiscoMovePhase,
       DiscoLoco,
+      DiscoActionNamingProvider,
     ];
   }
 }

--- a/src/maps/disco/view_settings.ts
+++ b/src/maps/disco/view_settings.ts
@@ -1,7 +1,6 @@
 import { ClickTarget, OnClickRegister } from "../../client/grid/click_target";
 import { useAction } from "../../client/services/action";
 import { useGrid, useInjected } from "../../client/utils/injection_context";
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { DiscoMoveHelper } from "./deliver";
 import { ProductionAction } from "./production";
@@ -13,13 +12,6 @@ export class DiscoInfernoViewSettings
   implements MapViewSettings
 {
   getMapRules = DiscoInfernoRules;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action === Action.PRODUCTION) {
-      return "Draw two cubes and place them in one city after the move goods step.";
-    }
-    return undefined;
-  }
 
   moveGoodsMessage(): string | undefined {
     const helper = useInjected(DiscoMoveHelper);

--- a/src/maps/germany/actions.ts
+++ b/src/maps/germany/actions.ts
@@ -1,0 +1,10 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class GermanyActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.ENGINEER) {
+      return "Build one tile (the most expensive one) at half price (rounded down).";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/germany/settings.ts
+++ b/src/maps/germany/settings.ts
@@ -14,6 +14,7 @@ import { GermanyCostCalculator } from "./cost";
 import { map } from "./grid";
 import { GermanyMoveHelper } from "./move";
 import { GermanyStarter } from "./starter";
+import { GermanyActionNamingProvider } from "./actions";
 
 export class GermanyMapSettings implements MapSettings {
   static readonly key = GameKey.GERMANY;
@@ -36,6 +37,7 @@ export class GermanyMapSettings implements MapSettings {
       GermanyBuildAction,
       GermanyBuildPhase,
       GermanyGoodsGrowth,
+      GermanyActionNamingProvider,
     ];
   }
 }

--- a/src/maps/germany/view_settings.ts
+++ b/src/maps/germany/view_settings.ts
@@ -1,4 +1,3 @@
-import { Action } from "../../engine/state/action";
 import { GermanyRules } from "./rules";
 import { GermanyMapSettings } from "./settings";
 import { MapViewSettings } from "../view_settings";
@@ -10,11 +9,4 @@ export class GermanyViewSettings
 {
   getMapRules = GermanyRules;
   getTexturesLayer = GermanyRivers;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action === Action.ENGINEER) {
-      return "Build one tile (the most expensive one) at half price (rounded down).";
-    }
-    return undefined;
-  }
 }

--- a/src/maps/india-steam-brothers/actions.ts
+++ b/src/maps/india-steam-brothers/actions.ts
@@ -1,0 +1,10 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class IndiaSteamBrothersActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.PRODUCTION) {
+      return "During the Goods Growth step, select a city, draw 2 goods, then place one of those goods in the selected city.";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/india-steam-brothers/settings.ts
+++ b/src/maps/india-steam-brothers/settings.ts
@@ -11,6 +11,7 @@ import {
   IndiaSteamBrothersPhaseDelegator,
   IndiaSteamBrothersPhaseEngine,
 } from "./production";
+import { IndiaSteamBrothersActionNamingProvider } from "./actions";
 
 export class IndiaSteamBrothersMapSettings implements MapSettings {
   static readonly key = GameKey.INDIA_STEAM_BROTHERS;
@@ -29,6 +30,7 @@ export class IndiaSteamBrothersMapSettings implements MapSettings {
       IndiaSteamBrothersPhaseDelegator,
       IndiaSteamBrothersBuildAction,
       IndiaSteamBrothersUrbanizeAction,
+      IndiaSteamBrothersActionNamingProvider,
     ];
   }
 }

--- a/src/maps/india-steam-brothers/view_settings.ts
+++ b/src/maps/india-steam-brothers/view_settings.ts
@@ -1,6 +1,5 @@
 import { ClickTarget, OnClickRegister } from "../../client/grid/click_target";
 import { useAction } from "../../client/services/action";
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { SelectCityAction } from "./production";
 import { IndiaSteamBrothersRivers } from "./rivers";
@@ -13,13 +12,6 @@ export class IndiaSteamBrothersViewSettings
 {
   getMapRules = IndiaSteamBrothersRules;
   getTexturesLayer = IndiaSteamBrothersRivers;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action === Action.PRODUCTION) {
-      return "During the Goods Growth step, select a city, draw 2 goods, then place one of those goods in the selected city.";
-    }
-    return undefined;
-  }
 
   useOnMapClick = useSelectCityOnClick;
 }

--- a/src/maps/ireland/actions.ts
+++ b/src/maps/ireland/actions.ts
@@ -1,0 +1,19 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+import { inject } from "../../engine/framework/execution_context";
+import { GameMemory } from "../../engine/game/game_memory";
+import { IrelandVariantConfig } from "../../api/variant_config";
+
+export class IrelandActionNamingProvider extends ActionNamingProvider {
+  private readonly gameMemory = inject(GameMemory);
+
+  getActionDescription(action: Action): string {
+    if (action === Action.LOCOMOTIVE) {
+      if (this.gameMemory.getVariant(IrelandVariantConfig.parse).locoVariant) {
+        return "Temporarily increase your locomotive by one for the round. Does not increase your expenses.";
+      } else {
+        return "Allows you to loco twice in one round.";
+      }
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/ireland/settings.ts
+++ b/src/maps/ireland/settings.ts
@@ -11,6 +11,7 @@ import { IrelandLocoAction, IrelandMoveHelper } from "./locomotive_action";
 import { IrelandAllowedActions, IrelandSelectAction } from "./select_action";
 import { IrelandRoundEngine } from "./shortened_round";
 import { IrelandStarter } from "./starter";
+import { IrelandActionNamingProvider } from "./actions";
 
 export class IrelandMapSettings implements MapSettings {
   static readonly key = GameKey.IRELAND;
@@ -35,6 +36,7 @@ export class IrelandMapSettings implements MapSettings {
       IrelandPhaseEngine,
       IrelandStarter,
       IrelandLocoAction,
+      IrelandActionNamingProvider,
     ];
   }
 }

--- a/src/maps/ireland/view_settings.ts
+++ b/src/maps/ireland/view_settings.ts
@@ -2,8 +2,6 @@ import { GameKey } from "../../api/game_key";
 import { IrelandVariantConfig, VariantConfig } from "../../api/variant_config";
 import { ClickTarget, OnClickRegister } from "../../client/grid/click_target";
 import { useAction } from "../../client/services/action";
-import { useGame } from "../../client/services/game";
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { DeurbanizeAction } from "./deurbanization";
 import { IrelandRivers } from "./rivers";
@@ -27,18 +25,6 @@ export class IrelandViewSettings
     if ((variant as IrelandVariantConfig).locoVariant) {
       return ["Loco"];
     }
-  }
-
-  getActionDescription(action: Action): string | undefined {
-    const game = useGame();
-    if (action === Action.LOCOMOTIVE) {
-      if (IrelandVariantConfig.parse(game.variant).locoVariant) {
-        return "Temporarily increase your locomotive by one for the round. Does not increase your expenses.";
-      } else {
-        return "Allows you to loco twice in one round.";
-      }
-    }
-    return undefined;
   }
 
   useOnMapClick = useDeurbanizeOnClick;

--- a/src/maps/london/actions.ts
+++ b/src/maps/london/actions.ts
@@ -1,0 +1,13 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class LondonActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.ENGINEER) {
+      return "Negotiate with the unions for lower overtime fees.";
+    }
+    if (action === Action.URBANIZATION) {
+      return "Add a New City to the board. Must replace an existing track segment.";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/london/settings.ts
+++ b/src/maps/london/settings.ts
@@ -12,6 +12,7 @@ import { LondonShareHelper } from "./shares";
 import { LondonUrbanizeAction } from "./urbanize";
 import { LondonPlayerHelper } from "./score";
 import { TurnLengthModule } from "../../modules/turn_length";
+import { LondonActionNamingProvider } from "./actions";
 
 export class LondonMapSettings implements MapSettings {
   static readonly key = GameKey.LONDON;
@@ -38,6 +39,7 @@ export class LondonMapSettings implements MapSettings {
       LondonShareHelper,
       LondonUrbanizeAction,
       LondonPlayerHelper,
+      LondonActionNamingProvider,
     ];
   }
 

--- a/src/maps/london/view_settings.ts
+++ b/src/maps/london/view_settings.ts
@@ -1,4 +1,3 @@
-import { Action } from "../../engine/state/action";
 import { LondonRules } from "./rules";
 import { LondonMapSettings } from "./settings";
 import { MapViewSettings } from "../view_settings";
@@ -12,16 +11,6 @@ export class LondonViewSettings
 {
   getMapRules = LondonRules;
   getTexturesLayer = LondonRivers;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action === Action.ENGINEER) {
-      return "Negotiate with the unions for lower overtime fees.";
-    }
-    if (action === Action.URBANIZATION) {
-      return "Add a New City to the board. Must replace an existing track segment.";
-    }
-    return undefined;
-  }
 
   getActionSummary(phase: Phase) {
     if (phase === Phase.MOVING) {

--- a/src/maps/madagascar/actions.ts
+++ b/src/maps/madagascar/actions.ts
@@ -1,0 +1,13 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class MadagascarActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.LOCOMOTIVE) {
+      return "Immediately, increase your locomotive by one, but you cannot build track this turn.";
+    }
+    if (action === Action.URBANIZATION) {
+      return "Place a new city on any town during the build step, but may only build one track tile.";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/madagascar/allowed_actions.ts
+++ b/src/maps/madagascar/allowed_actions.ts
@@ -7,8 +7,8 @@ import { GameStarter } from "../../engine/game/starter";
 import { AllowedActions } from "../../engine/select_action/allowed_actions";
 import {
   Action,
+  ActionNamingProvider,
   ActionZod,
-  getSelectedActionString,
 } from "../../engine/state/action";
 import { iterate, peek } from "../../utils/functions";
 import { ImmutableSet } from "../../utils/immutable";
@@ -57,6 +57,7 @@ export class MadagascarRoundEngine extends RoundEngine {
   private readonly disabledActions = injectState(DISABLED_ACTIONS);
   private readonly random = inject(Random);
   private readonly allowedActions = inject(AllowedActions);
+  private readonly actionNamingProvider = inject(ActionNamingProvider);
 
   start(round: number) {
     super.start(round);
@@ -82,7 +83,8 @@ export class MadagascarRoundEngine extends RoundEngine {
       newActions.push(allActions[nextActionIndex]);
     });
     this.log.log(
-      "Disabling actions " + newActions.map(getSelectedActionString).join(", "),
+      "Disabling actions " +
+        newActions.map(this.actionNamingProvider.getActionString).join(", "),
     );
     this.disabledActions.set(new Set(newActions));
   }

--- a/src/maps/madagascar/settings.ts
+++ b/src/maps/madagascar/settings.ts
@@ -23,6 +23,7 @@ import {
   MadagascarTurnOrderPass,
   MadagascarTurnOrderPhase,
 } from "./turn_order";
+import { MadagascarActionNamingProvider } from "./actions";
 
 export class MadagascarMapSettings implements MapSettings {
   static readonly key = GameKey.MADAGASCAR;
@@ -48,6 +49,7 @@ export class MadagascarMapSettings implements MapSettings {
       MadagascarRoundEngine,
       MadagascarTurnOrderPhase,
       MadagascarTurnOrderPass,
+      MadagascarActionNamingProvider,
     ];
   }
 }

--- a/src/maps/madagascar/view_settings.ts
+++ b/src/maps/madagascar/view_settings.ts
@@ -1,4 +1,3 @@
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { getActionCaption } from "./action_caption";
 import { MadagascarRules } from "./rules";
@@ -11,14 +10,4 @@ export class MadagascarViewSettings
   getMapRules = MadagascarRules;
 
   getActionCaption = getActionCaption;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action === Action.LOCOMOTIVE) {
-      return "Immediately, increase your locomotive by one, but you cannot build track this turn.";
-    }
-    if (action === Action.URBANIZATION) {
-      return "Place a new city on any town during the build step, but may only build one track tile.";
-    }
-    return undefined;
-  }
 }

--- a/src/maps/montreal_metro/actions.ts
+++ b/src/maps/montreal_metro/actions.ts
@@ -1,0 +1,10 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class MontrealActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.LOCOMOTIVE) {
+      return "Increases your government engine level.";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/montreal_metro/settings.ts
+++ b/src/maps/montreal_metro/settings.ts
@@ -24,6 +24,7 @@ import { MontrealMetroShareHelper } from "./max_shares";
 import { MontrealMetroRoundEngine } from "./rounds";
 import { MontrealAllowedActions } from "./select_action/allowed_actions";
 import { MontrealSelectAction } from "./select_action/montreal_select_action";
+import { MontrealActionNamingProvider } from "./actions";
 
 export class MontrealMetroMapSettings implements MapSettings {
   readonly key = GameKey.MONTREAL_METRO;
@@ -50,6 +51,7 @@ export class MontrealMetroMapSettings implements MapSettings {
       MontrealMetroMoveHelper,
       MontrealMetroBuilderHelper,
       MontrealMetroUrbanizeAction,
+      MontrealActionNamingProvider,
     ];
   }
 }

--- a/src/maps/montreal_metro/view_settings.ts
+++ b/src/maps/montreal_metro/view_settings.ts
@@ -1,6 +1,5 @@
 import { ClickTarget, OnClickRegister } from "../../client/grid/click_target";
 import { useAction } from "../../client/services/action";
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { GovtBuildOrder } from "./govt_build_order";
 import { LocoTrack } from "./loco_track";
@@ -16,13 +15,6 @@ export class MontrealMetroViewSettings
   getMapRules = MontrealMetroRules;
 
   getTexturesLayer = MontrealStreets;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action === Action.LOCOMOTIVE) {
-      return "Increases your government engine level.";
-    }
-    return undefined;
-  }
 
   additionalSliders = [LocoTrack, GovtBuildOrder];
 

--- a/src/maps/scotland/actions.ts
+++ b/src/maps/scotland/actions.ts
@@ -1,0 +1,10 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class ScotlandActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.TURN_ORDER_PASS) {
+      return "Become first player in the next round skipping auction phase.";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/scotland/settings.ts
+++ b/src/maps/scotland/settings.ts
@@ -12,6 +12,7 @@ import {
 } from "./ferries_connections";
 import { map } from "./grid";
 import { ScotlandPhaseEngine, ScotlandRoundEngine } from "./turn_order";
+import { ScotlandActionNamingProvider } from "./actions";
 
 export class ScotlandMapSettings implements MapSettings {
   readonly key = GameKey.SCOTLAND;
@@ -32,6 +33,7 @@ export class ScotlandMapSettings implements MapSettings {
       ScotlandBuildAction,
       ScotlandMoveValidator,
       ScotlandPhaseEngine,
+      ScotlandActionNamingProvider,
     ];
   }
 

--- a/src/maps/scotland/view_settings.ts
+++ b/src/maps/scotland/view_settings.ts
@@ -1,4 +1,3 @@
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { ScotlandRules } from "./rules";
 import { ScotlandRivers } from "./rivers";
@@ -10,11 +9,4 @@ export class ScotlandViewSettings
 {
   getMapRules = ScotlandRules;
   getTexturesLayer = ScotlandRivers;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action === Action.TURN_ORDER_PASS) {
-      return "Become first player in the next round skipping auction phase.";
-    }
-    return undefined;
-  }
 }

--- a/src/maps/soultrain/actions.ts
+++ b/src/maps/soultrain/actions.ts
@@ -1,0 +1,10 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class SoulTrainActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action == Action.ENGINEER) {
+      return "Cut the total cost of your build in half (rounded up).";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/soultrain/settings.ts
+++ b/src/maps/soultrain/settings.ts
@@ -15,6 +15,7 @@ import {
   SoulTrainRoundEngine,
 } from "./phases";
 import { SoulTrainStarter } from "./starter";
+import { SoulTrainActionNamingProvider } from "./actions";
 
 export class SoulTrainMapSettings implements MapSettings {
   readonly key = GameKey.SOUL_TRAIN;
@@ -36,6 +37,7 @@ export class SoulTrainMapSettings implements MapSettings {
       SoulTrainMoveAction,
       SoulTrainBuilderHelper,
       SoulTrainAllowedActions,
+      SoulTrainActionNamingProvider,
     ];
   }
 

--- a/src/maps/soultrain/view_settings.ts
+++ b/src/maps/soultrain/view_settings.ts
@@ -1,6 +1,5 @@
 import { ClickTarget, OnClickRegister } from "../../client/grid/click_target";
 import { useAction } from "../../client/services/action";
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { PlaceAction } from "./earth_to_heaven";
 import { SoulTrainRules } from "./rules";
@@ -11,12 +10,6 @@ export class SoulTrainViewSettings
   implements MapViewSettings
 {
   getMapRules = SoulTrainRules;
-
-  getActionDescription(action: Action): string | undefined {
-    if (action == Action.ENGINEER) {
-      return "Cut the total cost of your build in half (rounded up).";
-    }
-  }
   useOnMapClick = usePlaceOnClick;
 }
 

--- a/src/maps/st-lucia/actions.ts
+++ b/src/maps/st-lucia/actions.ts
@@ -1,0 +1,10 @@
+import { Action, ActionNamingProvider } from "../../engine/state/action";
+
+export class StLuciaActionNamingProvider extends ActionNamingProvider {
+  getActionDescription(action: Action): string {
+    if (action === Action.TURN_ORDER_PASS) {
+      return "Go first in the next auction.";
+    }
+    return super.getActionDescription(action);
+  }
+}

--- a/src/maps/st-lucia/settings.ts
+++ b/src/maps/st-lucia/settings.ts
@@ -8,6 +8,7 @@ import {
 } from "./bidding";
 import { map } from "./grid";
 import { StLuciaStarter } from "./starter";
+import { StLuciaActionNamingProvider } from "./actions";
 
 export class StLuciaMapSettings implements MapSettings {
   readonly key = GameKey.ST_LUCIA;
@@ -24,6 +25,7 @@ export class StLuciaMapSettings implements MapSettings {
       StLuciaStarter,
       StLuciaPhaseDelegator,
       StLuciaAllowedActions,
+      StLuciaActionNamingProvider,
     ];
   }
 }

--- a/src/maps/st-lucia/view_settings.ts
+++ b/src/maps/st-lucia/view_settings.ts
@@ -1,4 +1,3 @@
-import { Action } from "../../engine/state/action";
 import { MapViewSettings } from "../view_settings";
 import { StLuciaRivers } from "./rivers";
 import { StLuciaRules } from "./rules";
@@ -11,10 +10,4 @@ export class StLuciaViewSettings
   getTexturesLayer = StLuciaRivers;
 
   getMapRules = StLuciaRules;
-
-  getActionDescription?(action: Action): string | undefined {
-    if (action === Action.TURN_ORDER_PASS) {
-      return "Go first in the next auction.";
-    }
-  }
 }

--- a/src/maps/view_settings.ts
+++ b/src/maps/view_settings.ts
@@ -32,7 +32,6 @@ export interface MapViewSettings extends MapSettings {
   additionalSliders?: Array<() => ReactElement>;
   getVariantString?(variant: VariantConfig): string[] | undefined;
   getMapRules(props: RulesProps): ReactElement;
-  getActionDescription?(action: Action): string | undefined;
   getTexturesLayer?(props: TexturesProps): ReactNode;
   getFinalOverviewRows?(): RowFactory[];
   getActionCaption?(action: Action): string[] | string | undefined;


### PR DESCRIPTION
Have maps override this rather than implement an option ViewSettings method.

This makes it easy for maps that change both the name and description of an action to do so. For example, Sun which calls urbanization "restationing". (One could keep adding to the `Action` enum for every map, but this feels cleaner.)