### PR TITLE
Add overlay layer for view settings.

### DIFF
--- a/src/client/grid/hex_grid.tsx
+++ b/src/client/grid/hex_grid.tsx
@@ -136,6 +136,7 @@ export function HexGrid({
   const terrainHexes = {
     beforeTextures: [] as ReactNode[][],
     afterTextures: [] as ReactNode[][],
+    afterOverlay: [] as ReactNode[][],
   };
   for (const space of spaces) {
     const isHighlighted = useMemo(
@@ -181,6 +182,7 @@ export function HexGrid({
 
     aggregate(terrainHexes.beforeTextures, newTerrainHexes.beforeTextures);
     aggregate(terrainHexes.afterTextures, newTerrainHexes.afterTextures);
+    aggregate(terrainHexes.afterOverlay, newTerrainHexes.afterOverlay);
 
     function aggregate<T>(outputArr: T[][], inputArr: T[]) {
       for (const [index, space] of inputArr.entries()) {
@@ -193,10 +195,18 @@ export function HexGrid({
   }
 
   let texturesLayer: ReactNode = null;
+  let overlayLayer: ReactNode = null;
   if (gameKey) {
     const mapSettings = ViewRegistry.singleton.get(gameKey);
     if (mapSettings.getTexturesLayer) {
       texturesLayer = mapSettings.getTexturesLayer({
+        size,
+        grid,
+        clickTargets,
+      });
+    }
+    if (mapSettings.getOverlayLayer) {
+      overlayLayer = mapSettings.getOverlayLayer({
         size,
         grid,
         clickTargets,
@@ -318,6 +328,8 @@ export function HexGrid({
               {terrainHexes.beforeTextures}
               {texturesLayer}
               {terrainHexes.afterTextures}
+              {overlayLayer}
+              {terrainHexes.afterOverlay}
               {grid.connections.map((connection, index) => (
                 <InterCityConnectionRender
                   key={index}

--- a/src/maps/heavy_cardboard/rivers.tsx
+++ b/src/maps/heavy_cardboard/rivers.tsx
@@ -17,15 +17,6 @@ import {
 } from "../../utils/point";
 import { TexturesProps } from "../view_settings";
 
-export function HeavyCardboardTextures(props: TexturesProps) {
-  return (
-    <>
-      <HeavyCardboardCity {...props} />
-      <HeavyCardboardRivers />
-    </>
-  );
-}
-
 function movePointInRadDirections(
   point: Point,
   ...directions: [number, number][]
@@ -49,7 +40,11 @@ function polygonFromDirections(
   return points;
 }
 
-function HeavyCardboardCity({ grid, size, clickTargets }: TexturesProps) {
+export function HeavyCardboardOverlayLayer({
+  grid,
+  size,
+  clickTargets,
+}: TexturesProps) {
   const city = useMemo(() => {
     return grid.cities().find((city) => city.data.mapSpecific?.center)!;
   }, [grid]);
@@ -111,7 +106,7 @@ function HeavyCardboardCity({ grid, size, clickTargets }: TexturesProps) {
   );
 }
 
-function HeavyCardboardRivers() {
+export function HeavyCardboardRivers() {
   return (
     <>
       <path

--- a/src/maps/heavy_cardboard/view_settings.ts
+++ b/src/maps/heavy_cardboard/view_settings.ts
@@ -1,5 +1,5 @@
 import { MapViewSettings } from "../view_settings";
-import { HeavyCardboardTextures } from "./rivers";
+import { HeavyCardboardOverlayLayer, HeavyCardboardRivers } from "./rivers";
 import { HeavyCardboardRules } from "./rules";
 import { HeavyCardboardMapSettings } from "./settings";
 
@@ -8,5 +8,6 @@ export class HeavyCardboardViewSettings
   implements MapViewSettings
 {
   getMapRules = HeavyCardboardRules;
-  getTexturesLayer = HeavyCardboardTextures;
+  getTexturesLayer = HeavyCardboardRivers;
+  getOverlayLayer = HeavyCardboardOverlayLayer;
 }

--- a/src/maps/view_settings.ts
+++ b/src/maps/view_settings.ts
@@ -33,6 +33,7 @@ export interface MapViewSettings extends MapSettings {
   getVariantString?(variant: VariantConfig): string[] | undefined;
   getMapRules(props: RulesProps): ReactElement;
   getTexturesLayer?(props: TexturesProps): ReactNode;
+  getOverlayLayer?(props: TexturesProps): ReactNode;
   getFinalOverviewRows?(): RowFactory[];
   getActionCaption?(action: Action): string[] | string | undefined;
   moveGoodsMessage?(): string | undefined;


### PR DESCRIPTION
In particular this lets us make cities "upper terrain hexes" so that they get rendered over rivers (which may be present on new city hexes), while still allowing us to have an "overlay layer" separate from rivers which can still go over the cities.