### PR TITLE
Scandinavia Fixes

### DIFF
--- a/src/maps/scandinavia/claim_once.ts
+++ b/src/maps/scandinavia/claim_once.ts
@@ -1,0 +1,38 @@
+import z from "zod";
+import { ClaimAction, ClaimData } from "../../engine/build/claim";
+import { BuildPhase } from "../../engine/build/phase";
+import { injectState } from "../../engine/framework/execution_context";
+import { Key } from "../../engine/framework/key";
+import { assert } from "../../utils/validate";
+
+const HAS_CLAIMED = new Key("hasClaimed", { parse: z.boolean().parse });
+
+export class ScandinaviaBuildPhase extends BuildPhase {
+  private readonly hasClaimed = injectState(HAS_CLAIMED);
+
+  onStartTurn(): void {
+    this.hasClaimed.initState(false);
+    return super.onStartTurn();
+  }
+
+  onEndTurn(): void {
+    this.hasClaimed.delete();
+    return super.onEndTurn();
+  }
+}
+
+export class ScandinaviaClaimAction extends ClaimAction {
+  private readonly hasClaimed = injectState(HAS_CLAIMED);
+
+  validate(data: ClaimData): void {
+    assert(!this.hasClaimed(), {
+      invalidInput: "Can only claim one sea route per turn",
+    });
+    return super.validate(data);
+  }
+
+  process(data: ClaimData): boolean {
+    this.hasClaimed.set(true);
+    return super.process(data);
+  }
+}

--- a/src/maps/scandinavia/grid.ts
+++ b/src/maps/scandinavia/grid.ts
@@ -36,8 +36,9 @@ function coastal<T>(data: T): T & { mapSpecific: ScandinaviaMapData } {
 
 export const map = startsLowerGrid<SpaceData>([
   [
-    UNPASSABLE,
-    town("Söderhamn"),
+    WATER,
+    WATER,
+    coastal(town("Söderhamn")),
     PLAIN,
     PLAIN,
     ...duplicate(3, MOUNTAIN),
@@ -46,15 +47,27 @@ export const map = startsLowerGrid<SpaceData>([
     MOUNTAIN,
   ],
   [
-    UNPASSABLE,
-    UNPASSABLE,
+    WATER,
+    WATER,
+    WATER,
     PLAIN,
     PLAIN,
     { ...PLAIN, unpassableEdges: [TOP, TOP_LEFT] },
     ...duplicate(6, MOUNTAIN),
   ],
-  [PLAIN, RIVER, PLAIN, RIVER, PLAIN, PLAIN, RIVER, ...duplicate(3, MOUNTAIN)],
   [
+    WATER,
+    PLAIN,
+    RIVER,
+    PLAIN,
+    RIVER,
+    PLAIN,
+    PLAIN,
+    RIVER,
+    ...duplicate(3, MOUNTAIN),
+  ],
+  [
+    WATER,
     PLAIN,
     city("Uppsala", BLUE, white(1)),
     ...duplicate(4, RIVER),
@@ -65,6 +78,7 @@ export const map = startsLowerGrid<SpaceData>([
     MOUNTAIN,
   ],
   [
+    WATER,
     RIVER,
     RIVER,
     { ...PLAIN, unpassableEdges: [TOP_RIGHT, BOTTOM_RIGHT] },
@@ -77,6 +91,7 @@ export const map = startsLowerGrid<SpaceData>([
     MOUNTAIN,
   ],
   [
+    WATER,
     coastal(city("Stockholm", YELLOW, white(3))),
     ...duplicate(4, PLAIN),
     WATER,
@@ -87,6 +102,7 @@ export const map = startsLowerGrid<SpaceData>([
     MOUNTAIN,
   ],
   [
+    WATER,
     WATER,
     PLAIN,
     town("Norrköping"),
@@ -101,6 +117,7 @@ export const map = startsLowerGrid<SpaceData>([
   [
     WATER,
     WATER,
+    WATER,
     PLAIN,
     PLAIN,
     WATER,
@@ -111,6 +128,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
+    WATER,
     WATER,
     ...duplicate(5, PLAIN),
     coastal(city("Göteborg", YELLOW, white(6))),
@@ -125,6 +143,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
+    WATER,
     coastal(town("Visby")),
     WATER,
     ...duplicate(5, PLAIN),
@@ -135,6 +154,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
+    WATER,
     PLAIN,
     WATER,
     PLAIN,
@@ -150,6 +170,7 @@ export const map = startsLowerGrid<SpaceData>([
   [
     WATER,
     WATER,
+    WATER,
     coastal(town("Kalmar")),
     PLAIN,
     PLAIN,
@@ -162,7 +183,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
-    ...duplicate(4, WATER),
+    ...duplicate(5, WATER),
     PLAIN,
     bridge({
       tile: {
@@ -182,7 +203,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
-    ...duplicate(4, WATER),
+    ...duplicate(5, WATER),
     PLAIN,
     coastal(town("Malmö")),
     WATER,
@@ -193,7 +214,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
-    ...duplicate(4, WATER),
+    ...duplicate(5, WATER),
     bridge({
       tile: {
         ...startFrom(BOTTOM_LEFT).straightAcross(),
@@ -207,6 +228,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
+    WATER,
     coastal(city("Gdansk", RED, black(4))),
     PLAIN,
     WATER,
@@ -224,6 +246,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
+    WATER,
     ...duplicate(3, PLAIN),
     WATER,
     bridge({
@@ -239,6 +262,7 @@ export const map = startsLowerGrid<SpaceData>([
     WATER,
   ],
   [
+    UNPASSABLE,
     ...duplicate(4, PLAIN),
     coastal(city("Szczecin", PURPLE, black(6))),
     ...duplicate(4, PLAIN),

--- a/src/maps/scandinavia/grid.ts
+++ b/src/maps/scandinavia/grid.ts
@@ -187,7 +187,7 @@ export const map = startsLowerGrid<SpaceData>([
     coastal(town("Malmö")),
     WATER,
     { ...PLAIN, unpassableEdges: [BOTTOM] },
-    city("Odense", YELLOW, black(3)),
+    coastal(city("Odense", YELLOW, black(3))),
     { ...PLAIN, unpassableEdges: [TOP] },
     coastal(town("Flensburg")),
     WATER,

--- a/src/maps/scandinavia/rules.tsx
+++ b/src/maps/scandinavia/rules.tsx
@@ -6,7 +6,7 @@ export function ScandinaviaRules() {
         <li>
           <b>Sea Routes:</b> can be claimed for $6 and counts as a build. They
           can only be claimed if both ends have a city (i.e. have been
-          urbanized).
+          urbanized). Only one sea route can be claimed per turn.
         </li>
         <li>
           <b>Game ends:</b> one turn earlier.

--- a/src/maps/scandinavia/settings.ts
+++ b/src/maps/scandinavia/settings.ts
@@ -17,6 +17,7 @@ import {
   ScandinaviaMoveValidator,
 } from "./ferry";
 import { map } from "./grid";
+import { ScandinaviaBuildPhase, ScandinaviaClaimAction } from "./claim_once";
 
 export class ScandinaviaMapSettings implements MapSettings {
   readonly key = GameKey.SCANDINAVIA;
@@ -35,6 +36,8 @@ export class ScandinaviaMapSettings implements MapSettings {
       ScandinaviaMoveHelper,
       ScandinaviaMoveAction,
       ScandinaviaMovePhase,
+      ScandinaviaClaimAction,
+      ScandinaviaBuildPhase,
     ];
   }
 


### PR DESCRIPTION
Capturing the various clarifications that came up in the AoS Discord:
* Odense should be coastal
* Soderhamn should be coastal, and should be evidenced by water on the eastern side of the map
* It should only be allowed to build one sea route per turn