### PR TITLE
A couple of minor denmark fixes.

### DIFF
--- a/src/maps/denmark/locomotive_special_action.ts
+++ b/src/maps/denmark/locomotive_special_action.ts
@@ -12,13 +12,12 @@ import { getNextAvailableLinkValue } from "./loco";
 
 export class DenmarkMoveHelper extends MoveHelper {
   private readonly players = injectInGamePlayers();
-  private readonly currentPlayer = injectCurrentPlayer();
   private readonly phase = injectState(PHASE);
 
   getLocomotiveDisplay(player: PlayerData): string {
     if (this.canUseLoco(player)) {
-      const effectiveLink = this.getLocoLinkValue();
-      const currentLink = this.currentPlayer().locomotive;
+      const effectiveLink = this.getLocoLinkValue(player);
+      const currentLink = player.locomotive;
       return `${player.locomotive} (+${effectiveLink - currentLink})`;
     }
     return super.getLocomotiveDisplay(player);
@@ -26,7 +25,7 @@ export class DenmarkMoveHelper extends MoveHelper {
 
   getLocomotive(player: PlayerData): number {
     if (this.canUseLoco(player)) {
-      return this.getLocoLinkValue();
+      return this.getLocoLinkValue(player);
     }
     return super.getLocomotive(player);
   }
@@ -42,7 +41,7 @@ export class DenmarkMoveHelper extends MoveHelper {
     }
   }
 
-  private getLocoLinkValue() {
-    return getNextAvailableLinkValue(this.currentPlayer(), this.players());
+  private getLocoLinkValue(player: PlayerData) {
+    return getNextAvailableLinkValue(player, this.players());
   }
 }

--- a/src/maps/denmark/shares.ts
+++ b/src/maps/denmark/shares.ts
@@ -5,9 +5,9 @@ import {
 } from "../../engine/shares/take_shares";
 
 export class DenmarkShareHelper extends ShareHelper {
-  getMaxShares(): number {
-    // There is no limit to how many shares a player can take
-    return Infinity;
+  getSharesTheyCanTake(): number {
+    // Players can take shares until the limit of hitting -15 income.
+    return this.currentPlayer().income + 15;
   }
 }
 


### PR DESCRIPTION
* Apparently the maximum shares that can be taken is capped (cannot go lower than -15 income)
* The loco special action code was incorrectly referencing this.currentPlayer() instead of the passed-in player.