### PR TITLE
[Portugal] Sea routes and towns fix

### DIFF
--- a/src/maps/portugal/lisboa.ts
+++ b/src/maps/portugal/lisboa.ts
@@ -5,6 +5,8 @@ import {
   ConnectCitiesData,
 } from "../../engine/build/connect_cities";
 import { BuildPhase } from "../../engine/build/phase";
+import { Validator, InvalidBuildReason } from "../../engine/build/validator";
+import { BOTTOM, Direction } from "../../engine/state/tile";
 import { injectState } from "../../engine/framework/execution_context";
 import { Key } from "../../engine/framework/key";
 import { City } from "../../engine/map/city";
@@ -73,6 +75,9 @@ export class LisboaBuildAction extends BuildAction {
 export class LisboaConnectAction extends ConnectCitiesAction {
   private readonly connected = injectState(CONNECTED_TO_LISBOA);
 
+  protected validateUrbanizedCities(): void {
+  }
+
   validate(data: ConnectCitiesData): void {
     super.validate(data);
     // Only one connection out of Lisboa can be built per turn, per player.
@@ -91,6 +96,17 @@ export class LisboaConnectAction extends ConnectCitiesAction {
     return connection.connects
       .map((coordinates) => this.grid().get(coordinates))
       .some(isLisboa);
+  }
+}
+
+export class PortugalValidator extends Validator {
+  protected connectionAllowed(land: Land, exit: Direction): InvalidBuildReason|undefined {
+    if ((land.name() === "Sagres" || land.name() === "Sines")
+      && land.hasTown()
+      && exit === BOTTOM 
+    )  { return undefined }
+
+    return super.connectionAllowed(land, exit);
   }
 }
 

--- a/src/maps/portugal/settings.ts
+++ b/src/maps/portugal/settings.ts
@@ -14,6 +14,7 @@ import {
   LisboaBuildAction,
   LisboaBuildPhase,
   LisboaConnectAction,
+  PortugalValidator,
 } from "./lisboa";
 
 export class PortugalMapSettings implements MapSettings {
@@ -64,6 +65,7 @@ export class PortugalMapSettings implements MapSettings {
       LisboaBuildPhase,
       LisboaConnectAction,
       PortugalGoodsGrowthPhase,
+      PortugalValidator,
     ];
   }
 

--- a/src/maps/portugal/settings.ts
+++ b/src/maps/portugal/settings.ts
@@ -15,6 +15,7 @@ import {
   LisboaBuildPhase,
   LisboaConnectAction,
   PortugalValidator,
+  PortugalMoveValidator,
 } from "./lisboa";
 
 export class PortugalMapSettings implements MapSettings {
@@ -66,6 +67,7 @@ export class PortugalMapSettings implements MapSettings {
       LisboaConnectAction,
       PortugalGoodsGrowthPhase,
       PortugalValidator,
+      PortugalMoveValidator,
     ];
   }
 

--- a/src/maps/portugal/settings.ts
+++ b/src/maps/portugal/settings.ts
@@ -16,6 +16,7 @@ import {
   LisboaConnectAction,
   PortugalValidator,
   PortugalMoveValidator,
+  PortugalBuildPhase,
 } from "./lisboa";
 
 export class PortugalMapSettings implements MapSettings {
@@ -68,6 +69,7 @@ export class PortugalMapSettings implements MapSettings {
       PortugalGoodsGrowthPhase,
       PortugalValidator,
       PortugalMoveValidator,
+      PortugalBuildPhase,
     ];
   }
 


### PR DESCRIPTION
Ok, so that was a bit of a pain to fix as it goes against quite a few established rules.

Basically during a playthrough in my group some people instinctively assumed that you wouldn't need to have urbanized Sines or Sagres to establish a sea connection through them to Madeira or Lisboa. After some research it actually turned out (quite surprisingly) to be true. 

Details are in the lengthy exchange [here](https://boardgamegeek.com/thread/3493918/must-coastal-towns-be-urbanized-before-building-a). In that thread it has been explicitly stated by both the publisher AND the designer to be true.

What needed to be overwritten was:
a) possibility to build towards an unpassable edge for those 2 locations;
b) possibility to move goods through respective connections;
c) making sure the track to an unpassable edge won't dangle on next build phase end;

Still looks a bit off on the UI side but I'm not sure if much can be done about it.