### PR TITLE
C&O: Factory move confirm

### DIFF
--- a/src/client/grid/game_map.tsx
+++ b/src/client/grid/game_map.tsx
@@ -94,15 +94,12 @@ function confirmDeliveryCb(
     if (moveAction == null) return;
     const endingStop = grid.get(peek(moveAction.path).endingStop) as City;
     if (maybeInterceptMove(moveAction, endingStop.name())) return;
-    const income = moveInstance.value.calculateIncome(moveAction);
-    const counts = [...income]
-      .filter(([a]) => a != null)
-      .map(
-        ([owner, income]) =>
-          `${owner === player ? "you" : playerColorToString(owner)} ${income} income`,
-      );
-    const countsStr = counts.length > 0 ? counts.join(", ") : "zero income";
-    const message = `Deliver to ${endingStop.name()}? This will give ${countsStr}.`;
+    const message = getConfirmDeliveryMessage(
+      player,
+      moveAction,
+      grid,
+      moveInstance.value,
+    );
     confirm(message, {
       confirmButton: "Confirm Delivery",
       cancelButton: "Cancel",
@@ -114,6 +111,24 @@ function confirmDeliveryCb(
       });
     });
   };
+}
+
+export function getConfirmDeliveryMessage(
+  player: PlayerColor | undefined,
+  moveAction: MoveData,
+  grid: Grid,
+  moveInstance: MoveAction,
+) {
+  const endingStop = grid.get(peek(moveAction.path).endingStop) as City;
+  const income = moveInstance.calculateIncome(moveAction);
+  const counts = [...income]
+    .filter(([a]) => a != null)
+    .map(
+      ([owner, income]) =>
+        `${owner === player ? "you" : playerColorToString(owner)} ${income} income`,
+    );
+  const countsStr = counts.length > 0 ? counts.join(", ") : "zero income";
+  return `Deliver to ${endingStop.name()}? This will give ${countsStr}.`;
 }
 
 function getConfirmDeliveryCity(

--- a/src/client/grid/game_map.tsx
+++ b/src/client/grid/game_map.tsx
@@ -122,7 +122,7 @@ export function getConfirmDeliveryMessage(
   const endingStop = grid.get(peek(moveAction.path).endingStop) as City;
   const income = moveInstance.calculateIncome(moveAction);
   const counts = [...income]
-    .filter(([a]) => a != null)
+    .filter(([owner, income]) => owner != null && income != 0)
     .map(
       ([owner, income]) =>
         `${owner === player ? "you" : playerColorToString(owner)} ${income} income`,

--- a/src/maps/chesapeake-and-ohio/move_interceptor.ts
+++ b/src/maps/chesapeake-and-ohio/move_interceptor.ts
@@ -1,0 +1,23 @@
+import { MoveData } from "../../engine/move/move";
+import { MoveInterceptor } from "../../engine/move/interceptor";
+import { injectGrid } from "../../engine/game/state";
+import { ChesapeakeAndOhioMapData } from "./build";
+
+export class ChesapeakeAndOhioMoveInterceptor extends MoveInterceptor {
+  private readonly grid = injectGrid();
+
+  public shouldInterceptMove(moveData: MoveData, _cityName: string): boolean {
+    // Intercept if there is a factory at the destination
+    const destination = this.grid().get(
+      moveData.path[moveData.path.length - 1].endingStop,
+    );
+    if (destination === undefined) {
+      return false;
+    }
+    const mapData = destination.getMapSpecific(ChesapeakeAndOhioMapData.parse);
+    if (mapData && mapData.factoryColor !== undefined) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/maps/chesapeake-and-ohio/move_interceptor_modal.tsx
+++ b/src/maps/chesapeake-and-ohio/move_interceptor_modal.tsx
@@ -1,0 +1,61 @@
+import {InterceptMoveModalProps} from "../../engine/move/interceptor";
+import {useAction} from "../../client/services/action";
+import React, {useCallback} from "react";
+import {Memoized, useCurrentPlayer, useGrid, useInjectedMemo,} from "../../client/utils/injection_context";
+import {playerColorToString} from "../../engine/state/player";
+import {Confirm,} from "semantic-ui-react";
+import * as styles from "../../client/components/confirm.module.css";
+import {MoveAction, MoveData} from "../../engine/move/move";
+import {capitalizeFirstLetter} from "../../utils/functions";
+import {getConfirmDeliveryMessage} from "../../client/grid/game_map";
+import {ChesapeakeAndOhioMapData} from "./build";
+
+export function ChesapeakeAndOhioMoveInterceptorModal({
+  moveData,
+  clearMoveData: clearMoveDataExternal,
+}: InterceptMoveModalProps) {
+  if (!moveData) return null;
+
+  const { emit: emitMoveAction } = useAction(MoveAction);
+  const grid = useGrid();
+  const player = useCurrentPlayer();
+  const moveInstance: Memoized<MoveAction<MoveData>> =
+    useInjectedMemo(MoveAction);
+
+  const clearMoveData = useCallback(() => {
+    clearMoveDataExternal();
+  }, [clearMoveDataExternal]);
+
+  const completeMove = useCallback(() => {
+    emitMoveAction(moveData);
+    clearMoveData();
+  }, [emitMoveAction, clearMoveData, moveData]);
+
+  const message = getConfirmDeliveryMessage(
+    player?.color,
+    moveData,
+    grid,
+    moveInstance.value,
+  );
+  const factoryColor = grid
+    .get(moveData.path[moveData.path.length - 1].endingStop)
+    ?.getMapSpecific(ChesapeakeAndOhioMapData.parse)?.factoryColor;
+  const factoryMessage = factoryColor
+    ? `${capitalizeFirstLetter(factoryColor === player?.color ? "you" : playerColorToString(factoryColor))} will receive 1 additional income for delivering to a factory. Then two random cubes will be drawn and added to the destination city.`
+    : undefined;
+  const content = <>
+    <p>{message}</p>
+    {factoryMessage ? <p>{factoryMessage}</p> : null}
+    </>
+
+  return <Confirm
+      open={moveData != null}
+      content={{content: content}}
+      onCancel={clearMoveData}
+      onConfirm={completeMove}
+      confirmButton="Confirm Delivery"
+      cancelButton="Cancel"
+      size="large"
+      className={styles.modal}
+  />
+}

--- a/src/maps/chesapeake-and-ohio/settings.ts
+++ b/src/maps/chesapeake-and-ohio/settings.ts
@@ -22,6 +22,7 @@ import { map } from "./grid";
 import { ChesapeakeAndOhioPhaseEngine } from "./phase";
 import { ChesapeakeAndOhioStarter } from "./starter";
 import { ChesapeakeAndOhioUrbanizeAction } from "./urbanize";
+import { ChesapeakeAndOhioMoveInterceptor } from "./move_interceptor";
 
 export class ChesapeakeAndOhioMapSettings implements MapSettings {
   static readonly key = GameKey.CHESAPEAKE_AND_OHIO;
@@ -49,6 +50,7 @@ export class ChesapeakeAndOhioMapSettings implements MapSettings {
       ChesapeakeAndOhioLocoAction,
       ChesapeakeAndOhioActionNamingProvider,
       ChesapeakeAndOhioMoveValidator,
+      ChesapeakeAndOhioMoveInterceptor,
     ];
   }
 }

--- a/src/maps/chesapeake-and-ohio/view_settings.ts
+++ b/src/maps/chesapeake-and-ohio/view_settings.ts
@@ -10,6 +10,7 @@ import {
   ChesapeakeAndOhioOverlayLayer,
   ChesapeakeAndOhioRivers,
 } from "./rivers";
+import { ChesapeakeAndOhioMoveInterceptorModal } from "./move_interceptor_modal";
 
 export class ChesapeakeAndOhioViewSettings
   extends ChesapeakeAndOhioMapSettings
@@ -18,6 +19,7 @@ export class ChesapeakeAndOhioViewSettings
   getMapRules = ChesapeakeAndOhioRules;
   getTexturesLayer = ChesapeakeAndOhioRivers;
   getOverlayLayer = ChesapeakeAndOhioOverlayLayer;
+  moveInterceptModal = ChesapeakeAndOhioMoveInterceptorModal;
 
   getActionSummary(phase: Phase) {
     if (phase === Phase.BUILDING) {

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -1,6 +1,13 @@
 import { Entry, Primitive } from "./types";
 import { assert } from "./validate";
 
+export function capitalizeFirstLetter(str: string) {
+  if (str.length === 0) {
+    return str;
+  }
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
 export function peek<T>(arr: T[]): T {
   return arr[arr.length - 1];
 }


### PR DESCRIPTION
When delivering to a city with a factory, include context about additional income and drawn cubes in delivery confirmation modal.

There might be a simpler way to allow maps to customize the delivery confirmation message without implementing a full-blown custom move interceptor modal, but I couldn't come up with anything particularly clever so I just went with the most straightforward option.