### PR TITLE
Add quick development environment setup with Docker Compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+.git
+.gitignore
+.env
+*.md
+*.log
+coverage
+.nyc_output
+.DS_Store
+Thumbs.db
+.vscode
+.idea
+docker-compose*.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24-alpine
+
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ Special thanks to all the [contributors](https://github.com/YourDeveloperFriend/
 
 Please submit [issues](https://github.com/YourDeveloperFriend/choochoo/issues) and [pull requests](https://github.com/YourDeveloperFriend/choochoo/pulls).
 
+### Quick Start with Docker Compose (Recommended)
+
+The easiest way to get started is using Docker Compose. This will start the service and watch for changes.
+
+```bash
+docker-compose up --watch
+```
+
+Visit http://localhost:3001 to see the application.
+
+**Note:** 
+- If you encounter port conflicts, check for existing services with `lsof -i :PORT_NUMBER`
+
+### Manual Setup
+
+Alternatively, you can set up services manually.
+
 To run locally, you should start a local postgres and redis instance.
 With docker you can run:
 
@@ -31,4 +48,3 @@ export SESSION_SECRET=foobar
 
 Apply database migrations with `npm run migrate`.
 You can then start up a server with `npm run dev`.
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  postgres:
+    image: postgres:15
+    container_name: choochoo-pg
+    environment:
+      POSTGRES_DB: choochoo
+      POSTGRES_USER: choochoo
+      POSTGRES_PASSWORD: choochoo
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U choochoo -d choochoo"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: choochoo-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  app:
+    build: .
+    container_name: choochoo-app
+    ports:
+      - "3001:3000"
+    environment:
+      NODE_ENV: development
+      POSTGRES_URL: postgresql://choochoo:choochoo@postgres:5432/choochoo
+      REDIS_URL: redis://redis:6379
+      SESSION_SECRET: foobar-dev
+      PORT: 3000
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - /app/node_modules
+      - /app/dist
+    command: sh -c "npm run build-server && npm run migrate && npm run dev"
+    develop:
+      watch:
+        - action: sync
+          path: ./src
+          target: /app/src
+        - action: rebuild
+          path: ./package*.json
+
+volumes:
+  postgres_data:
+  redis_data: 


### PR DESCRIPTION
This adds a Docker Compose configuration that allows starting local development environment with one simple command
```
docker compose up --watch
```