### PR TITLE
Fix delivery logic for UPE chaining.

### DIFF
--- a/src/maps/union_pacific_express/move.ts
+++ b/src/maps/union_pacific_express/move.ts
@@ -31,7 +31,7 @@ export class UnionPacificExpressMoveHelper extends MoveHelper {
   isWithinLocomotive(player: PlayerData, moveData: MoveData): boolean {
     return (
       moveData.path.length +
-        this.unionPacificExpressMoveState().visitedLocations.length <=
+        (this.unionPacificExpressMoveState().visitedLocations?.length || 0) <=
       player.locomotive
     );
   }


### PR DESCRIPTION
Rather than the C&O logic which said you can't re-use links (which is still true), the rules for UPE are actually stronger in that you cannot revisit locations (the same rules as a basic delivery). This updates the delivery state to track the visited locations rather than the used links. (Based on observation, there aren't any UPE games in progress on the site, so I think this is ok to merge without worrying about mismatched state on existing games in progress.)