### PR TITLE
Revert "Tweak UPE delivery fix to be backwards compatible."

### DIFF
--- a/src/maps/union_pacific_express/deliver.ts
+++ b/src/maps/union_pacific_express/deliver.ts
@@ -6,7 +6,7 @@ import { LocoAction } from "../../engine/move/loco";
 import { MoveAction, MoveData } from "../../engine/move/move";
 import { MovePhase } from "../../engine/move/phase";
 import { SpaceType } from "../../engine/state/location_type";
-import { PlayerColorZod, PlayerData } from "../../engine/state/player";
+import { PlayerData } from "../../engine/state/player";
 import { Coordinates, CoordinatesZod } from "../../utils/coordinates";
 import { assert } from "../../utils/validate";
 import { MoveValidator } from "../../engine/move/validator";
@@ -16,17 +16,8 @@ import { UnionPacificExpressMapData } from "./grid";
 
 export const BAILEY_YARD_SAME_CITY = 1;
 
-const UsedLink = z.object({
-  start: CoordinatesZod,
-  end: CoordinatesZod,
-  owner: PlayerColorZod.optional(),
-});
-type UsedLink = z.infer<typeof UsedLink>;
-
-// FIXME: Remove usedLinks and make visitedLocations some time after these changes are merged and there are no move phases in progress from before this refactor
 const UnionPacificExpressMoveState = z.object({
-  visitedLocations: CoordinatesZod.array().optional(),
-  usedLinks: UsedLink.array().optional(),
+  visitedLocations: CoordinatesZod.array(),
 });
 type UnionPacificExpressMoveState = z.infer<
   typeof UnionPacificExpressMoveState
@@ -66,8 +57,7 @@ export class UnionPacificExpressMovePassAction extends MovePassAction {
 
   validate(data: EmptyAction): void {
     super.validate(data);
-    const state = this.unionPacificExpressMoveState();
-    assert((!state.visitedLocations || state.visitedLocations.length === 0), {
+    assert(this.unionPacificExpressMoveState().visitedLocations.length === 0, {
       invalidInput: "cannot pass when using a transfer station",
     });
   }
@@ -96,9 +86,6 @@ export class UnionPacificExpressMoveAction extends MoveAction {
         city.goods.push(action.good);
       });
       this.unionPacificExpressMoveState.update((val) => {
-        if (!val.visitedLocations) {
-          val.visitedLocations = [];
-        }
         // Add starting and intermediate locations to visited locations, but not the ending one (the transfer station)
         val.visitedLocations.push(action.startingCity);
         for (let i = 0; i < action.path.length - 1; i++) {
@@ -119,7 +106,7 @@ export class UnionPacificExpressMoveValidator extends MoveValidator {
 
   validate(player: PlayerData, action: MoveData) {
     super.validate(player, action);
-    const { usedLinks, visitedLocations } = this.unionPacificExpressMoveState();
+    const { visitedLocations } = this.unionPacificExpressMoveState();
 
     const startingCity = this.grid().get(action.startingCity);
     const mapSpecific = startingCity?.getMapSpecific(
@@ -127,13 +114,13 @@ export class UnionPacificExpressMoveValidator extends MoveValidator {
     );
     const transferStation =
       mapSpecific !== undefined && !!mapSpecific.transferStation;
-    if ((usedLinks && usedLinks.length > 0) || (visitedLocations && visitedLocations.length > 0)) {
-      assert(transferStation, {
-        invalidInput: `must continue chained delivery from the transfer station`,
-      });
-    } else {
+    if (visitedLocations.length === 0) {
       assert(!transferStation, {
         invalidInput: `cannot start deliveries from the transfer station`,
+      });
+    } else {
+      assert(transferStation, {
+        invalidInput: `must continue chained delivery from the transfer station`,
       });
     }
 
@@ -142,11 +129,8 @@ export class UnionPacificExpressMoveValidator extends MoveValidator {
 
   private validateVisitedLocationsNotReused(
     action: MoveData,
-    visitedLocations: Coordinates[]|undefined,
+    visitedLocations: Coordinates[],
   ) {
-    if (!visitedLocations) {
-      return;
-    }
     for (const newLoc of [action.startingCity].concat(
       action.path.map((step) => step.endingStop),
     )) {
@@ -164,7 +148,7 @@ export class UnionPacificExpressLocoAction extends LocoAction {
 
   validate(): void {
     super.validate();
-    assert((this.unionPacificExpressMoveState().visitedLocations?.length || 0) === 0, {
+    assert(this.unionPacificExpressMoveState().visitedLocations.length === 0, {
       invalidInput: "cannot loco in the middle of a delivery chain",
     });
   }

--- a/src/maps/union_pacific_express/move.ts
+++ b/src/maps/union_pacific_express/move.ts
@@ -31,7 +31,7 @@ export class UnionPacificExpressMoveHelper extends MoveHelper {
   isWithinLocomotive(player: PlayerData, moveData: MoveData): boolean {
     return (
       moveData.path.length +
-        (this.unionPacificExpressMoveState().visitedLocations?.length || 0) <=
+        this.unionPacificExpressMoveState().visitedLocations.length <=
       player.locomotive
     );
   }


### PR DESCRIPTION
Cleans up the optional() and various tweaks to ensure the move state was backwards compatible to games in progress. [This](https://www.choochoo.games/app/games/1166) appears to be the only UPE game in progress that's in a move phase (though there may be some unlisted ones). At any rate, I'll plan to keep this as draft for a week (which should hopefully be long enough for any games in progress to make their move and purge stale move state) and then merge this in after 11/13.