### PR TITLE
Fix typo in town name from 'Opale' to 'Opole'

### DIFF
--- a/src/maps/poland/grid.ts
+++ b/src/maps/poland/grid.ts
@@ -43,7 +43,7 @@ export const map = grid([
     PLAIN,
     city("Bydgoszcz", Good.BLUE, white(2), 2),
     ...duplicate(4, PLAIN),
-    town("Opale"),
+    town("Opole"),
     DARK_MOUNTAIN,
   ],
   [


### PR DESCRIPTION
For reference, here is the link to wiki about this town: https://en.wikipedia.org/wiki/Opole?useskin=vector
