### PR TITLE
Replace drop-shadow on goods cubes with a 3d cube rendering instead.

### DIFF
--- a/src/client/grid/good.module.css
+++ b/src/client/grid/good.module.css
@@ -1,23 +1,29 @@
 .black {
   --good-color: #444444;
+  --good-background-color: #282828;
 }
 
 .blue {
   --good-color: #00a2d3;
+  --good-background-color: #007ba0;
 }
 
 .purple {
   --good-color: #8d5a95;
+  --good-background-color: #5b3a60;
 }
 
 .red {
   --good-color: #d41e2d;
+  --good-background-color: #a01622;
 }
 
 .yellow {
   --good-color: #f5ac11;
+  --good-background-color: #c1880d;
 }
 
 .white {
   --good-color: #e9dcc9;
+  --good-background-color: #b5aa9b;
 }

--- a/src/client/grid/good_block.module.css
+++ b/src/client/grid/good_block.module.css
@@ -1,3 +1,6 @@
 .good {
   fill: var(--good-color);
 }
+.goodBackground {
+  fill: var(--good-background-color);
+}

--- a/src/client/grid/good_block.tsx
+++ b/src/client/grid/good_block.tsx
@@ -31,7 +31,8 @@ export function GoodBlock({
   rotation,
 }: GoodBlockProps) {
   const goodSize = size / 3;
-  const maxGoodsPerRow = 6;
+  const maxGoodsPerRow = 5;
+  const goodSpacing = goodSize * 0.75;
 
   // Render 6 goods per row
   const xOffset = offset % maxGoodsPerRow;
@@ -44,7 +45,9 @@ export function GoodBlock({
       : goodsCount % maxGoodsPerRow;
 
   const x =
-    center.x - (goodSize * (rowSize + 1)) / 2 / 2 + (xOffset * goodSize) / 2;
+    center.x -
+    (goodSpacing * (rowSize - 1) + goodSize) / 2 +
+    xOffset * goodSpacing;
   const y = center.y + yOffset * goodSize * 1.5 - size * 0.75;
   const stroke = highlighted
     ? good === Good.YELLOW
@@ -56,17 +59,22 @@ export function GoodBlock({
   const strokeWidth = highlighted ? 2 : 1;
   return (
     <Rotate rotation={rotation} center={center} reverse={true}>
-      <rect
-        fill="black"
-        width={goodSize}
-        height={goodSize}
-        x={x}
-        y={y}
-        strokeWidth={0}
+      <polygon
+        points={`${x},${y} ${x + goodSize},${y} ${x + goodSize * 1.3},${y + goodSize * 0.3} ${x + goodSize * 1.3},${y + goodSize * 1.3} ${x + goodSize * 0.3},${y + goodSize * 1.3} ${x},${y + goodSize}`}
+        className={`${styles.goodBackground} ${goodStyle(good)}`}
+        strokeWidth={strokeWidth}
+        stroke={stroke}
+      />
+      <line
+        x1={x + goodSize}
+        y1={y + goodSize}
+        x2={x + goodSize * 1.3}
+        y2={y + goodSize * 1.3}
+        strokeWidth={strokeWidth}
+        stroke={stroke}
       />
       <rect
         className={`${clickable ? hexGridStyles.clickable : ""} ${styles.good} ${goodStyle(good)}`}
-        filter={`url(#cubeShadow)`}
         data-coordinates={coordinates.serialize()}
         data-good={good}
         width={goodSize}

--- a/src/client/grid/hex_grid.tsx
+++ b/src/client/grid/hex_grid.tsx
@@ -315,13 +315,6 @@ export function HexGrid({
               size={size}
             />
           )}
-          <defs>
-            <filter id="cubeShadow" width={size / 3} height={size / 3}>
-              <feOffset in="SourceAlpha" dx={size / 15} dy={size / 15} />
-              <feGaussianBlur stdDeviation={size / 30} />
-              <feBlend in="SourceGraphic" in2="blurOut" />
-            </filter>
-          </defs>
           <g ref={ref}>
             {/* Rotating without a center moves it along the origin, but we rely on the viewBox calculation to make sure the view box fits the content. */}
             <Rotate rotation={rotation}>
@@ -331,12 +324,12 @@ export function HexGrid({
               {overlayLayer}
               {terrainHexes.afterOverlay}
               <InterCityConnectionsRender
-                  highlightedConnections={highlightedConnections}
-                  clickTargets={clickTargetsNormalized}
-                  onClick={onClickInterCity}
-                  size={size}
-                  connections={grid.connections}
-                  rotation={rotation}
+                highlightedConnections={highlightedConnections}
+                clickTargets={clickTargetsNormalized}
+                onClick={onClickInterCity}
+                size={size}
+                connections={grid.connections}
+                rotation={rotation}
               />
               {fullMapVersion && <SwedenProgressionGraphic />}
               {children}

--- a/src/maps/double_base_usa/overlay_layer.tsx
+++ b/src/maps/double_base_usa/overlay_layer.tsx
@@ -4,23 +4,42 @@ import { coordinatesToCenter } from "../../utils/point";
 import { DoubleBaseUsaMapData } from "./grid";
 
 export function DoubleBaseUsaOverlayLayer(props: TexturesProps) {
+  const goodSize = props.size / 3;
+
   const result: ReactNode[] = [];
   for (const [_, space] of props.grid.entries()) {
     const mapData = space.getMapSpecific(DoubleBaseUsaMapData.parse);
     if (mapData && mapData.hasLandGrant === true) {
       const center = coordinatesToCenter(space.coordinates, props.size);
+      const x = center.x - goodSize / 2;
+      const y = center.y + props.size * 0.2;
 
       result.push(
-        <rect
-          filter={`url(#cubeShadow)`}
-          width={props.size / 3}
-          height={props.size / 3}
-          x={center.x - props.size / 6}
-          y={center.y + props.size * 0.2}
-          fill="#90ee90"
-          strokeWidth={1}
-          stroke="black"
-        />,
+        <>
+          <polygon
+            points={`${x},${y} ${x + goodSize},${y} ${x + goodSize * 1.3},${y + goodSize * 0.3} ${x + goodSize * 1.3},${y + goodSize * 1.3} ${x + goodSize * 0.3},${y + goodSize * 1.3} ${x},${y + goodSize}`}
+            strokeWidth={1}
+            stroke="black"
+            fill="#71ba71"
+          />
+          <line
+            x1={x + goodSize}
+            y1={y + goodSize}
+            x2={x + goodSize * 1.3}
+            y2={y + goodSize * 1.3}
+            strokeWidth={1}
+            stroke="black"
+          />
+          <rect
+            width={goodSize}
+            height={goodSize}
+            x={x}
+            y={y}
+            strokeWidth={1}
+            stroke="black"
+            fill="#90ee90"
+          />
+        </>,
       );
     }
   }


### PR DESCRIPTION
As discussed over on the dev channel to resolve bug-inducing behavior in Safari.
<img width="421" height="318" alt="Screenshot 2025-12-20 at 16 13 20" src="https://github.com/user-attachments/assets/3af8765c-b855-4af6-b86b-1d32f7fbdec8" />
