### PR TITLE
Revert "Skip production during goods growth since it applies immediately."

### DIFF
--- a/src/maps/double_base_usa/production.ts
+++ b/src/maps/double_base_usa/production.ts
@@ -13,8 +13,6 @@ import { SelectActionPhase } from "../../engine/select_action/phase";
 import { PHASE } from "../../engine/game/phase";
 import { Phase } from "../../engine/state/phase";
 import { Log } from "../../engine/game/log";
-import { GoodsGrowthPhase } from "../../engine/goods_growth/phase";
-import { PlayerColor } from "../../engine/state/player";
 
 const ProductionState = z.object({
   goods: GoodZod.array(),
@@ -96,11 +94,5 @@ export class ProductionAction implements ActionProcessor<ProductionData> {
     );
     this.productionState.set({ goods: [] });
     return true;
-  }
-}
-
-export class DoubleBaseUsaGoodsGrowthPhase extends GoodsGrowthPhase {
-  getPlayerOrder(): PlayerColor[] {
-    return [];
   }
 }

--- a/src/maps/double_base_usa/settings.ts
+++ b/src/maps/double_base_usa/settings.ts
@@ -22,10 +22,7 @@ import {
   DoubleBaseUsaConnectCitiesAction,
   DoubleBaseUsaCostCalculator,
 } from "./build";
-import {
-  DoubleBaseUsaGoodsGrowthPhase,
-  DoubleBaseUsaSelectActionPhase,
-} from "./production";
+import { DoubleBaseUsaSelectActionPhase } from "./production";
 import {
   DoubleBaseUsaMoveAction,
   DoubleBaseUsaMoveHelper,
@@ -82,7 +79,6 @@ export class DoubleBaseUsaMapSettings implements MapSettings {
       DoubleBaseUsaRoundEngine,
       DoubleBaseUsaBuildPhase,
       DoubleBaseUsaUrbanizeAction,
-      DoubleBaseUsaGoodsGrowthPhase,
     ];
   }
 }


### PR DESCRIPTION
Temporarily roll this back so we can get past the production phase on a game in progress, then will roll this forward again.