### PR TITLE
Tweak goods on hexes to avoid overlap with city number.

### DIFF
--- a/src/client/grid/good_block.tsx
+++ b/src/client/grid/good_block.tsx
@@ -36,7 +36,9 @@ export function GoodBlock({
 
   // Render 6 goods per row
   const xOffset = offset % maxGoodsPerRow;
-  const yOffset = Math.floor(offset / maxGoodsPerRow);
+  const row = Math.floor(offset / maxGoodsPerRow);
+  // Put the second row in the third-row position to limit overlap with the city numbers; third row goes in second row position
+  const yOffset = (row === 1 ? 2 : (row === 2 ? 1 : row));
 
   const rowSize =
     Math.floor(offset / maxGoodsPerRow) <


### PR DESCRIPTION
<img width="203" height="140" alt="Screenshot 2026-01-01 at 18 27 08" src="https://github.com/user-attachments/assets/e7028fd6-750e-4dc5-bb4a-3e1373d711a7" />
