### PR TITLE
Support a user allowlist for maps in the development stage.

### DIFF
--- a/src/client/game/create_page.tsx
+++ b/src/client/game/create_page.tsx
@@ -49,7 +49,8 @@ export function CreateGamePage() {
           (map) =>
             environment.stage === "development" ||
             map.stage !== ReleaseStage.DEVELOPMENT ||
-            me?.role === UserRole.enum.ADMIN,
+            me?.role === UserRole.enum.ADMIN ||
+            (map.developmentAllowlist !== undefined && me !== undefined && map.developmentAllowlist.indexOf(me.id) !== -1)
         )
         .sort((a, b) => (a.name < b.name ? -1 : 1)),
     [],

--- a/src/engine/game/map_settings.ts
+++ b/src/engine/game/map_settings.ts
@@ -56,6 +56,8 @@ export interface MapSettings {
   readonly interCityConnections?: InterCityConnection[];
   readonly stage: ReleaseStage;
   readonly rotation?: Rotation;
+  // Development maps get an allowlist of user IDs who are allowed to create games for that map
+  readonly developmentAllowlist?: number[];
 
   getOverrides(): Array<SimpleConstructor<unknown>>;
   getModules?(): Array<Module>;

--- a/src/server/game/routes.ts
+++ b/src/server/game/routes.ts
@@ -23,6 +23,8 @@ import {
   remainingPlayers,
   startGame,
 } from "./logic";
+import { MapRegistry } from "../../maps/registry";
+import { ReleaseStage } from "../../engine/game/map_settings";
 
 export const gameApp = express();
 
@@ -126,6 +128,21 @@ const router = initServer().router(gameContract, {
   async create({ body, req }) {
     const userId = req.session.userId;
     assert(userId != null, { permissionDenied: true });
+    const user = await assertRole(req);
+    const isAdmin = user.role === UserRole.enum.ADMIN;
+
+    const map = MapRegistry.singleton.get(body.gameKey);
+    assert(map != null, { invalidInput: true });
+    assert(
+      stage() === Stage.enum.development ||
+        map.stage !== ReleaseStage.DEVELOPMENT ||
+        isAdmin ||
+        (map.developmentAllowlist !== undefined &&
+          map.developmentAllowlist.indexOf(userId) === -1),
+      { permissionDenied: true },
+    );
+    assert(map.stage !== ReleaseStage.DEVELOPMENT || body.unlisted, { invalidInput: "Development map games must be unlisted." });
+
     const playerIds = [userId];
     if (body.artificialStart) {
       assert(stage() === Stage.enum.development);
@@ -270,7 +287,10 @@ const router = initServer().router(gameContract, {
       const game = await GameDao.findByPk(gameId, { transaction });
       assert(game != null);
       assert(gameHistory != null);
-      assert(game.status === GameStatus.Enum.ACTIVE, 'cannot undo an ended game');
+      assert(
+        game.status === GameStatus.Enum.ACTIVE,
+        "cannot undo an ended game",
+      );
       assert(
         game.version === gameHistory.previousGameVersion + 1,
         "can only undo one step",


### PR DESCRIPTION
This makes it easier for non-admins to add maps still under development by restricting creation of tables for that map to an allowlist of testers.