### PR TITLE
clarify log message for expenses

### DIFF
--- a/src/engine/income_and_expenses/expenses.ts
+++ b/src/engine/income_and_expenses/expenses.ts
@@ -25,7 +25,7 @@ export class ExpensesPhase extends PhaseModule {
         if (profit > 0) {
           this.log.player(player, `earns $${profit}`);
         } else {
-          this.log.player(player, `loses $${-profit}`);
+          this.log.player(player, `pays $${-profit} for expenses`);
         }
       } else {
         this.log.player(


### PR DESCRIPTION
I found that the current log message for expenses was a little vague. It's not so much that you're _losing_ money, you're paying money for expenses. 

I added a change to reflect that. 