### PR TITLE
Montreal Metro - remove turn order pass

### DIFF
--- a/src/maps/montreal_metro/select_action/allowed_actions.ts
+++ b/src/maps/montreal_metro/select_action/allowed_actions.ts
@@ -5,7 +5,7 @@ import { Action } from "../../../engine/state/action";
 export class MontrealAllowedActions extends AllowedActions {
   getActions(): ImmutableSet<Action> {
     return super.getActions().withMutations((set) => {
-      set.delete(Action.PRODUCTION).add(Action.REPOPULATION);
+      set.delete(Action.PRODUCTION).delete(Action.TURN_ORDER_PASS).add(Action.REPOPULATION);
     });
   }
 }


### PR DESCRIPTION
Fixes #228

Montreal Metro shouldn't have the Turn Order Pass. Removed. 