### PR TITLE
Fix -10 income reduction starting at 50.

### DIFF
--- a/src/engine/income_and_expenses/reduction.ts
+++ b/src/engine/income_and_expenses/reduction.ts
@@ -32,7 +32,7 @@ export class IncomeReductionPhase extends PhaseModule {
 
   protected calculateIncomeReduction(income: number): number {
     if (income <= 10) return 0;
-    if (income >= 51) return 10;
+    if (income >= 50) return 10;
     return Math.floor((income - 1) / 10) * 2;
   }
 


### PR DESCRIPTION
While inconsistent, the [EGG rules](https://drive.google.com/file/d/1mYf5e7dtxdCFmHSEwgSgnCNI9885sfMG/view?usp=sharing) are explicit that -10 income reduction starts at 50 and not 51.

> If a player’s railroad’s income is over 49, that income is reduced by 10.