### PR TITLE
Add 4 Loco map (development stage)

### DIFF
--- a/src/api/game_key.ts
+++ b/src/api/game_key.ts
@@ -47,6 +47,7 @@ export enum GameKey {
   CHICAGO_L = "chicago-l",
   MINAS_GERAES = "minas-geraes",
   JAPAN = "japan",
+  FOUR_LOCO = "four-loco",
 }
 
 export const GameKeyZod = z.nativeEnum(GameKey);

--- a/src/api/variant_config.ts
+++ b/src/api/variant_config.ts
@@ -46,6 +46,7 @@ const EmptyVariantConfig = z.object({
     GameKey.CHICAGO_L,
     GameKey.MINAS_GERAES,
     GameKey.JAPAN,
+    GameKey.FOUR_LOCO,
   ]),
 });
 type EmptyVariantConfig = z.infer<typeof EmptyVariantConfig>;

--- a/src/engine/game/map_settings.ts
+++ b/src/engine/game/map_settings.ts
@@ -44,6 +44,7 @@ export const GRIMIKU = 99;
 export const EMIL = 375;
 export const CORTEXBOMB = 387;
 export const ZEZZO = 164;
+export const CHAD_DESHON = 102;
 
 export enum PlayerCountRating {
   NO_DATA = "?",

--- a/src/engine/income_and_expenses/expenses.ts
+++ b/src/engine/income_and_expenses/expenses.ts
@@ -10,10 +10,10 @@ import { ProfitHelper } from "./helper";
 export class ExpensesPhase extends PhaseModule {
   static readonly phase = Phase.EXPENSES;
 
-  private readonly profitHelper = inject(ProfitHelper);
-  private readonly log = inject(Log);
-  private readonly moneyManager = inject(MoneyManager);
-  private readonly players = injectPlayersByTurnOrder();
+  protected readonly profitHelper = inject(ProfitHelper);
+  protected readonly log = inject(Log);
+  protected readonly moneyManager = inject(MoneyManager);
+  protected readonly players = injectPlayersByTurnOrder();
 
   onStart(): void {
     for (const player of this.players()) {

--- a/src/maps/four_loco/actions.ts
+++ b/src/maps/four_loco/actions.ts
@@ -20,6 +20,6 @@ export class FourLocoAllowedActions extends AllowedActions {
  */
 export class FourLocoLocoAction extends LocoAction {
   validate(): void {
-    fail({ invalidArgument: "Locomotive action is not available on this map" });
+    fail({ invalidInput: "Locomotive action is not available on this map" });
   }
 }

--- a/src/maps/four_loco/actions.ts
+++ b/src/maps/four_loco/actions.ts
@@ -1,6 +1,8 @@
 import { Set as ImmutableSet } from "immutable";
 import { AllowedActions } from "../../engine/select_action/allowed_actions";
 import { Action } from "../../engine/state/action";
+import { LocoAction } from "../../engine/move/loco";
+import { fail } from "../../utils/validate";
 
 /**
  * In 4 Loco, the Locomotive action is removed from the action selection phase.
@@ -9,5 +11,15 @@ import { Action } from "../../engine/state/action";
 export class FourLocoAllowedActions extends AllowedActions {
   getActions(): ImmutableSet<Action> {
     return super.getActions().remove(Action.LOCOMOTIVE);
+  }
+}
+
+/**
+ * Guards against any code path that tries to invoke the Locomotive action
+ * directly during the move phase.
+ */
+export class FourLocoLocoAction extends LocoAction {
+  validate(): void {
+    fail({ invalidArgument: "Locomotive action is not available on this map" });
   }
 }

--- a/src/maps/four_loco/actions.ts
+++ b/src/maps/four_loco/actions.ts
@@ -1,0 +1,13 @@
+import { Set as ImmutableSet } from "immutable";
+import { AllowedActions } from "../../engine/select_action/allowed_actions";
+import { Action } from "../../engine/state/action";
+
+/**
+ * In 4 Loco, the Locomotive action is removed from the action selection phase.
+ * All players start at engine level 4 and cannot increase it further.
+ */
+export class FourLocoAllowedActions extends AllowedActions {
+  getActions(): ImmutableSet<Action> {
+    return super.getActions().remove(Action.LOCOMOTIVE);
+  }
+}

--- a/src/maps/four_loco/deliver.ts
+++ b/src/maps/four_loco/deliver.ts
@@ -1,0 +1,204 @@
+import { z } from "zod";
+import { inject, injectState } from "../../engine/framework/execution_context";
+import { Key } from "../../engine/framework/key";
+import { ActionBundle } from "../../engine/game/phase_module";
+import { EmptyAction } from "../../engine/game/action";
+import { injectCurrentPlayer } from "../../engine/game/state";
+import { MoveAction, MoveData } from "../../engine/move/move";
+import { MovePhase } from "../../engine/move/phase";
+import { MovePassAction } from "../../engine/move/pass";
+import { MoveSearcher } from "../../engine/move/searcher";
+import { MoveValidator, RouteInfo } from "../../engine/move/validator";
+import { Coordinates } from "../../utils/coordinates";
+import { PlayerColor, PlayerData } from "../../engine/state/player";
+import { assert } from "../../utils/validate";
+
+// ---------------------------------------------------------------------------
+// State: track which players have passed consecutively in this delivery phase.
+// When a player makes a delivery, the list resets — everyone must pass again.
+// The phase ends only when ALL players appear in this list.
+// ---------------------------------------------------------------------------
+
+const FourLocoPassState = z.object({
+  passedPlayers: z.array(z.nativeEnum(PlayerColor)),
+});
+type FourLocoPassState = z.infer<typeof FourLocoPassState>;
+
+export const FOUR_LOCO_PASS_STATE = new Key("fourLocoPassState", {
+  parse: FourLocoPassState.parse,
+});
+
+// ---------------------------------------------------------------------------
+// FourLocoMovePhase
+// Overrides the delivery phase to allow unlimited rounds until all players
+// pass consecutively.
+// ---------------------------------------------------------------------------
+
+export class FourLocoMovePhase extends MovePhase {
+  private readonly fourLocoPassState = injectState(FOUR_LOCO_PASS_STATE);
+  private readonly moveSearcher = inject(MoveSearcher);
+  private readonly currentPlayer = injectCurrentPlayer();
+
+  configureActions() {
+    // Install our overridden pass and move actions; skip LocoAction
+    this.installAction(FourLocoMoveAction);
+    this.installAction(FourLocoMovePassAction);
+  }
+
+  onStart(): void {
+    super.onStart();
+    this.fourLocoPassState.initState({ passedPlayers: [] });
+  }
+
+  onEnd(): void {
+    this.fourLocoPassState.delete();
+    super.onEnd();
+  }
+
+  /**
+   * We don't use the standard "numMoveRounds" mechanism — our cycling logic
+   * is handled entirely via findNextPlayer. Return 1 so the base class never
+   * bumps the round counter prematurely.
+   */
+  numMoveRounds(): number {
+    return 1;
+  }
+
+  /**
+   * After each turn the engine asks for the next player. We keep cycling
+   * through the full turn order until every player has passed consecutively
+   * (i.e., no delivery was made since the last reset of passedPlayers).
+   */
+  findNextPlayer(currPlayer: PlayerColor): PlayerColor | undefined {
+    const next = super.findNextPlayer(currPlayer);
+    if (next != null) {
+      return next;
+    }
+
+    // We've reached the end of one cycle through turn order.
+    const playerOrder = this.getPlayerOrder();
+    const passed = this.fourLocoPassState().passedPlayers;
+
+    // If every player in the order appears in passedPlayers, we're done.
+    if (playerOrder.every((p) => passed.includes(p))) {
+      return undefined;
+    }
+
+    // Otherwise continue with another round starting from the first player.
+    return playerOrder[0];
+  }
+
+  /**
+   * Auto-pass when the current player has no valid 4-link deliveries.
+   * This avoids requiring players to manually click Pass when they're stuck.
+   */
+  forcedAction(): ActionBundle<object> | undefined {
+    const player = this.currentPlayer();
+    const validRoutes = this.moveSearcher.findAllRoutes(player);
+    if (validRoutes.length === 0) {
+      return { action: FourLocoMovePassAction, data: {} };
+    }
+    return undefined;
+  }
+
+  /** Called by FourLocoMovePassAction to record this player's pass. */
+  recordPass(player: PlayerColor): void {
+    this.fourLocoPassState.update((state) => {
+      if (!state.passedPlayers.includes(player)) {
+        state.passedPlayers.push(player);
+      }
+    });
+  }
+
+  /** Called by FourLocoMoveAction after a successful delivery — resets pass tracking. */
+  recordDelivery(): void {
+    this.fourLocoPassState.update((state) => {
+      state.passedPlayers = [];
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FourLocoMovePassAction
+// Records the current player's pass in the phase state.
+// ---------------------------------------------------------------------------
+
+export class FourLocoMovePassAction extends MovePassAction {
+  private readonly phase = inject(FourLocoMovePhase);
+  private readonly currentPlayer = injectCurrentPlayer();
+
+  process(_: EmptyAction): boolean {
+    const result = super.process(_);
+    this.phase.recordPass(this.currentPlayer().color);
+    return result;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FourLocoMoveAction
+// - Always awards exactly 2 income to the delivering player.
+// - Resets pass tracking after each delivery.
+// ---------------------------------------------------------------------------
+
+export class FourLocoMoveAction extends MoveAction {
+  private readonly phase = inject(FourLocoMovePhase);
+  private readonly currentPlayerState = injectCurrentPlayer();
+
+  calculateIncome(_action: MoveData): Map<PlayerColor, number> {
+    // Always exactly 2 income credited to the current player only.
+    return new Map([[this.currentPlayerState().color, 2]]);
+  }
+
+  process(action: MoveData): boolean {
+    const result = super.process(action);
+    this.phase.recordDelivery();
+    return result;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FourLocoMoveValidator
+// - Requires exactly 4 links per delivery.
+// - Only allows using the current player's own track.
+// ---------------------------------------------------------------------------
+
+export class FourLocoMoveValidator extends MoveValidator {
+  private readonly currentPlayer = injectCurrentPlayer();
+
+  validatePartial(player: PlayerData, action: MoveData): void {
+    // Run base validation first (locomotive check, duplicate stops, etc.)
+    super.validatePartial(player, action);
+    // Allow partial paths up to 4 links so MoveSearcher can find valid routes.
+    // Exact length of 4 is enforced in validateEnd for complete deliveries.
+    assert(action.path.length <= 4, {
+      invalidInput: "4 Loco requires exactly 4 links per delivery",
+    });
+  }
+
+  validateEnd(action: MoveData): void {
+    assert(action.path.length === 4, {
+      invalidInput: "4 Loco requires exactly 4 links per delivery",
+    });
+    super.validateEnd(action);
+  }
+
+  /**
+   * Override to restrict route discovery to tracks where EVERY tile
+   * belongs to the current player.  The base implementation only stores the
+   * *first* tile's owner in RouteInfo.owner, so multi-tile routes that span
+   * different players' tiles would be incorrectly allowed by a simple owner
+   * filter on RouteInfo.  Using grid.getRoute() we inspect the full tile set.
+   */
+  findRoutesFromLocation(fromCoordinates: Coordinates): RouteInfo[] {
+    const allRoutes = super.findRoutesFromLocation(fromCoordinates);
+    const currentPlayerColor = this.currentPlayer().color;
+    const grid = this.grid();
+    return allRoutes.filter((route) => {
+      if (route.type !== "track") return false;
+      // Every physical tile in this route segment must be owned by the current player.
+      return grid
+        .getRoute(route.startingTrack)
+        .every((tile) => tile.getOwner() === currentPlayerColor);
+    });
+  }
+}

--- a/src/maps/four_loco/deliver.ts
+++ b/src/maps/four_loco/deliver.ts
@@ -8,15 +8,15 @@ import { MoveAction, MoveData } from "../../engine/move/move";
 import { MovePhase } from "../../engine/move/phase";
 import { MovePassAction } from "../../engine/move/pass";
 import { MoveSearcher } from "../../engine/move/searcher";
-import { MoveValidator, RouteInfo } from "../../engine/move/validator";
-import { Coordinates } from "../../utils/coordinates";
+import { MoveValidator } from "../../engine/move/validator";
 import { PlayerColor, PlayerData } from "../../engine/state/player";
 import { assert } from "../../utils/validate";
 
 // ---------------------------------------------------------------------------
-// State: track which players have passed consecutively in this delivery phase.
-// When a player makes a delivery, the list resets — everyone must pass again.
-// The phase ends only when ALL players appear in this list.
+// State: track which players have passed in this delivery phase.
+// When a player makes a delivery, the list resets — everyone must pass again
+// (but note: once a player passes, they are done until the next reset).
+// The phase ends only when ALL players appear in this list consecutively.
 // ---------------------------------------------------------------------------
 
 const FourLocoPassState = z.object({
@@ -31,7 +31,7 @@ export const FOUR_LOCO_PASS_STATE = new Key("fourLocoPassState", {
 // ---------------------------------------------------------------------------
 // FourLocoMovePhase
 // Overrides the delivery phase to allow unlimited rounds until all players
-// pass consecutively.
+// pass (once you pass, you are done unless the state is reset by a delivery).
 // ---------------------------------------------------------------------------
 
 export class FourLocoMovePhase extends MovePhase {
@@ -65,27 +65,30 @@ export class FourLocoMovePhase extends MovePhase {
   }
 
   /**
-   * After each turn the engine asks for the next player. We keep cycling
-   * through the full turn order until every player has passed consecutively
-   * (i.e., no delivery was made since the last reset of passedPlayers).
+   * After each turn, find the next player who has NOT yet passed.
+   * If all players have passed, the phase ends.
+   * When a delivery is made, passedPlayers resets, so everyone is eligible
+   * again.
    */
   findNextPlayer(currPlayer: PlayerColor): PlayerColor | undefined {
-    const next = super.findNextPlayer(currPlayer);
-    if (next != null) {
-      return next;
-    }
-
-    // We've reached the end of one cycle through turn order.
     const playerOrder = this.getPlayerOrder();
     const passed = this.fourLocoPassState().passedPlayers;
 
-    // If every player in the order appears in passedPlayers, we're done.
+    // If every player has passed consecutively, end the phase.
     if (playerOrder.every((p) => passed.includes(p))) {
       return undefined;
     }
 
-    // Otherwise continue with another round starting from the first player.
-    return playerOrder[0];
+    // Find the next player in order after currPlayer who hasn't passed.
+    const currIndex = playerOrder.indexOf(currPlayer);
+    for (let i = 1; i <= playerOrder.length; i++) {
+      const candidate = playerOrder[(currIndex + i) % playerOrder.length];
+      if (!passed.includes(candidate)) {
+        return candidate;
+      }
+    }
+
+    return undefined;
   }
 
   /**
@@ -100,36 +103,25 @@ export class FourLocoMovePhase extends MovePhase {
     }
     return undefined;
   }
-
-  /** Called by FourLocoMovePassAction to record this player's pass. */
-  recordPass(player: PlayerColor): void {
-    this.fourLocoPassState.update((state) => {
-      if (!state.passedPlayers.includes(player)) {
-        state.passedPlayers.push(player);
-      }
-    });
-  }
-
-  /** Called by FourLocoMoveAction after a successful delivery — resets pass tracking. */
-  recordDelivery(): void {
-    this.fourLocoPassState.update((state) => {
-      state.passedPlayers = [];
-    });
-  }
 }
 
 // ---------------------------------------------------------------------------
 // FourLocoMovePassAction
-// Records the current player's pass in the phase state.
+// Records the current player's pass in the shared state.
 // ---------------------------------------------------------------------------
 
 export class FourLocoMovePassAction extends MovePassAction {
-  private readonly phase = inject(FourLocoMovePhase);
+  private readonly fourLocoPassState = injectState(FOUR_LOCO_PASS_STATE);
   private readonly currentPlayer = injectCurrentPlayer();
 
   process(_: EmptyAction): boolean {
     const result = super.process(_);
-    this.phase.recordPass(this.currentPlayer().color);
+    const color = this.currentPlayer().color;
+    this.fourLocoPassState.update((state) => {
+      if (!state.passedPlayers.includes(color)) {
+        state.passedPlayers.push(color);
+      }
+    });
     return result;
   }
 }
@@ -137,11 +129,11 @@ export class FourLocoMovePassAction extends MovePassAction {
 // ---------------------------------------------------------------------------
 // FourLocoMoveAction
 // - Always awards exactly 2 income to the delivering player.
-// - Resets pass tracking after each delivery.
+// - Resets pass tracking after each delivery so everyone can deliver again.
 // ---------------------------------------------------------------------------
 
 export class FourLocoMoveAction extends MoveAction {
-  private readonly phase = inject(FourLocoMovePhase);
+  private readonly fourLocoPassState = injectState(FOUR_LOCO_PASS_STATE);
   private readonly currentPlayerState = injectCurrentPlayer();
 
   calculateIncome(_action: MoveData): Map<PlayerColor, number> {
@@ -151,7 +143,10 @@ export class FourLocoMoveAction extends MoveAction {
 
   process(action: MoveData): boolean {
     const result = super.process(action);
-    this.phase.recordDelivery();
+    // Reset pass tracking: a delivery was made, so everyone is eligible again.
+    this.fourLocoPassState.update((state) => {
+      state.passedPlayers = [];
+    });
     return result;
   }
 }
@@ -159,7 +154,7 @@ export class FourLocoMoveAction extends MoveAction {
 // ---------------------------------------------------------------------------
 // FourLocoMoveValidator
 // - Requires exactly 4 links per delivery.
-// - Only allows using the current player's own track.
+// - Only allows using the current player's own track (checked via step.owner).
 // ---------------------------------------------------------------------------
 
 export class FourLocoMoveValidator extends MoveValidator {
@@ -169,7 +164,6 @@ export class FourLocoMoveValidator extends MoveValidator {
     // Run base validation first (locomotive check, duplicate stops, etc.)
     super.validatePartial(player, action);
     // Allow partial paths up to 4 links so MoveSearcher can find valid routes.
-    // Exact length of 4 is enforced in validateEnd for complete deliveries.
     assert(action.path.length <= 4, {
       invalidInput: "4 Loco requires exactly 4 links per delivery",
     });
@@ -179,26 +173,13 @@ export class FourLocoMoveValidator extends MoveValidator {
     assert(action.path.length === 4, {
       invalidInput: "4 Loco requires exactly 4 links per delivery",
     });
-    super.validateEnd(action);
-  }
-
-  /**
-   * Override to restrict route discovery to tracks where EVERY tile
-   * belongs to the current player.  The base implementation only stores the
-   * *first* tile's owner in RouteInfo.owner, so multi-tile routes that span
-   * different players' tiles would be incorrectly allowed by a simple owner
-   * filter on RouteInfo.  Using grid.getRoute() we inspect the full tile set.
-   */
-  findRoutesFromLocation(fromCoordinates: Coordinates): RouteInfo[] {
-    const allRoutes = super.findRoutesFromLocation(fromCoordinates);
+    // Every step must be owned by the current player.
     const currentPlayerColor = this.currentPlayer().color;
-    const grid = this.grid();
-    return allRoutes.filter((route) => {
-      if (route.type !== "track") return false;
-      // Every physical tile in this route segment must be owned by the current player.
-      return grid
-        .getRoute(route.startingTrack)
-        .every((tile) => tile.getOwner() === currentPlayerColor);
-    });
+    for (const step of action.path) {
+      assert(step.owner === currentPlayerColor, {
+        invalidInput: "4 Loco requires using only your own track",
+      });
+    }
+    super.validateEnd(action);
   }
 }

--- a/src/maps/four_loco/deliver.ts
+++ b/src/maps/four_loco/deliver.ts
@@ -1,13 +1,11 @@
 import { z } from "zod";
-import { inject, injectState } from "../../engine/framework/execution_context";
+import { injectState } from "../../engine/framework/execution_context";
 import { Key } from "../../engine/framework/key";
-import { ActionBundle } from "../../engine/game/phase_module";
 import { EmptyAction } from "../../engine/game/action";
 import { injectCurrentPlayer } from "../../engine/game/state";
 import { MoveAction, MoveData } from "../../engine/move/move";
 import { MovePhase } from "../../engine/move/phase";
 import { MovePassAction } from "../../engine/move/pass";
-import { MoveSearcher } from "../../engine/move/searcher";
 import { MoveValidator } from "../../engine/move/validator";
 import { PlayerColor, PlayerData } from "../../engine/state/player";
 import { assert } from "../../utils/validate";
@@ -36,8 +34,6 @@ export const FOUR_LOCO_PASS_STATE = new Key("fourLocoPassState", {
 
 export class FourLocoMovePhase extends MovePhase {
   private readonly fourLocoPassState = injectState(FOUR_LOCO_PASS_STATE);
-  private readonly moveSearcher = inject(MoveSearcher);
-  private readonly currentPlayer = injectCurrentPlayer();
 
   configureActions() {
     // Install our overridden pass and move actions; skip LocoAction
@@ -91,18 +87,6 @@ export class FourLocoMovePhase extends MovePhase {
     return undefined;
   }
 
-  /**
-   * Auto-pass when the current player has no valid 4-link deliveries.
-   * This avoids requiring players to manually click Pass when they're stuck.
-   */
-  forcedAction(): ActionBundle<object> | undefined {
-    const player = this.currentPlayer();
-    const validRoutes = this.moveSearcher.findAllRoutes(player);
-    if (validRoutes.length === 0) {
-      return { action: FourLocoMovePassAction, data: {} };
-    }
-    return undefined;
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/maps/four_loco/expenses.ts
+++ b/src/maps/four_loco/expenses.ts
@@ -1,11 +1,9 @@
 import { inject } from "../../engine/framework/execution_context";
-import { Log } from "../../engine/game/log";
 import { PlayerHelper } from "../../engine/game/player";
-import { injectPlayersByTurnOrder } from "../../engine/game/state";
 import { ExpensesPhase } from "../../engine/income_and_expenses/expenses";
 import { ProfitHelper } from "../../engine/income_and_expenses/helper";
-import { TakeSharesAction, TakeSharesData } from "../../engine/shares/take_shares";
 import { ShareHelper } from "../../engine/shares/share_helper";
+import { TakeSharesAction, TakeSharesData } from "../../engine/shares/take_shares";
 import { PlayerData } from "../../engine/state/player";
 
 const SHARE_COST = 3;
@@ -50,11 +48,8 @@ export class FourLocoTakeSharesAction extends TakeSharesAction {
  * After issuing the minimum required shares, the normal expense deduction runs.
  */
 export class FourLocoExpensesPhase extends ExpensesPhase {
-  private readonly profitHelper = inject(ProfitHelper);
-  private readonly log = inject(Log);
   private readonly playerHelper = inject(PlayerHelper);
   private readonly shareHelper = inject(ShareHelper);
-  private readonly players = injectPlayersByTurnOrder();
 
   onStart(): void {
     for (const player of this.players()) {

--- a/src/maps/four_loco/expenses.ts
+++ b/src/maps/four_loco/expenses.ts
@@ -1,0 +1,73 @@
+import { inject } from "../../engine/framework/execution_context";
+import { Log } from "../../engine/game/log";
+import { MoneyManager } from "../../engine/game/money_manager";
+import { PlayerHelper } from "../../engine/game/player";
+import { injectPlayersByTurnOrder } from "../../engine/game/state";
+import { ExpensesPhase } from "../../engine/income_and_expenses/expenses";
+import { ProfitHelper } from "../../engine/income_and_expenses/helper";
+import { PlayerData } from "../../engine/state/player";
+
+const FORCED_SHARE_COST = 3;
+
+/**
+ * In 4 Loco, engine level does NOT count toward expenses.
+ * Players only pay for their shares (not locomotive level).
+ */
+export class FourLocoProfitHelper extends ProfitHelper {
+  getExpenses(player: PlayerData): number {
+    return player.shares;
+  }
+}
+
+/**
+ * In 4 Loco, when a player cannot afford expenses they are forced to issue
+ * shares at $3 each (instead of losing income).  Normal share-phase shares
+ * still cost $5 — this override only applies at the expense step.
+ */
+export class FourLocoExpensesPhase extends ExpensesPhase {
+  private readonly flProfitHelper = inject(ProfitHelper);
+  private readonly flLog = inject(Log);
+  private readonly flMoneyManager = inject(MoneyManager);
+  private readonly flPlayerHelper = inject(PlayerHelper);
+  private readonly flPlayers = injectPlayersByTurnOrder();
+
+  onStart(): void {
+    for (const player of this.flPlayers()) {
+      const expenses = this.flProfitHelper.getExpenses(player);
+
+      if (player.money < expenses) {
+        const deficit = expenses - player.money;
+        const sharesNeeded = Math.ceil(deficit / FORCED_SHARE_COST);
+
+        this.flPlayerHelper.update(player.color, (p) => {
+          p.shares += sharesNeeded;
+          p.money += FORCED_SHARE_COST * sharesNeeded;
+        });
+
+        this.flLog.player(
+          player,
+          `cannot afford expenses and is forced to issue ${sharesNeeded} share${sharesNeeded === 1 ? "" : "s"} at $${FORCED_SHARE_COST} each`,
+        );
+      }
+
+      const result = this.flMoneyManager.addMoney(player.color, -expenses, true);
+
+      if (result.lostIncome === 0) {
+        const profit = this.flProfitHelper.getProfit(player);
+        if (profit > 0) {
+          this.flLog.player(player, `earns $${profit}`);
+        } else {
+          this.flLog.player(player, `pays $${-profit} for expenses`);
+        }
+      } else {
+        this.flLog.player(
+          player,
+          `cannot afford expenses and loses ${result.lostIncome} income`,
+        );
+        if (result.outOfGame) {
+          this.flLog.player(player, `drops out of the game`);
+        }
+      }
+    }
+  }
+}

--- a/src/maps/four_loco/expenses.ts
+++ b/src/maps/four_loco/expenses.ts
@@ -1,13 +1,14 @@
 import { inject } from "../../engine/framework/execution_context";
 import { Log } from "../../engine/game/log";
-import { MoneyManager } from "../../engine/game/money_manager";
 import { PlayerHelper } from "../../engine/game/player";
 import { injectPlayersByTurnOrder } from "../../engine/game/state";
 import { ExpensesPhase } from "../../engine/income_and_expenses/expenses";
 import { ProfitHelper } from "../../engine/income_and_expenses/helper";
+import { TakeSharesAction, TakeSharesData } from "../../engine/shares/take_shares";
+import { ShareHelper } from "../../engine/shares/share_helper";
 import { PlayerData } from "../../engine/state/player";
 
-const FORCED_SHARE_COST = 3;
+const SHARE_COST = 3;
 
 /**
  * In 4 Loco, engine level does NOT count toward expenses.
@@ -20,54 +21,66 @@ export class FourLocoProfitHelper extends ProfitHelper {
 }
 
 /**
+ * In 4 Loco, all shares (both voluntary and emergency) cost $3 instead of $5.
+ */
+export class FourLocoTakeSharesAction extends TakeSharesAction {
+  process({ numShares }: TakeSharesData): boolean {
+    if (this.helper.getSharesTheyCanTake() === 0) {
+      this.log.currentPlayer(`cannot take out anymore shares`);
+    } else if (numShares === 0) {
+      this.log.currentPlayer("does not take out any shares");
+    } else {
+      this.log.currentPlayer(
+        `takes out ${numShares} shares and receives $${SHARE_COST * numShares}`,
+      );
+    }
+
+    this.playerHelper.updateCurrentPlayer((player) => {
+      player.shares += numShares;
+      player.money += SHARE_COST * numShares;
+    });
+
+    return true;
+  }
+}
+
+/**
  * In 4 Loco, when a player cannot afford expenses they are forced to issue
- * shares at $3 each (instead of losing income).  Normal share-phase shares
- * still cost $5 — this override only applies at the expense step.
+ * emergency shares at $3 each (instead of losing income).
+ * After issuing the minimum required shares, the normal expense deduction runs.
  */
 export class FourLocoExpensesPhase extends ExpensesPhase {
-  private readonly flProfitHelper = inject(ProfitHelper);
-  private readonly flLog = inject(Log);
-  private readonly flMoneyManager = inject(MoneyManager);
-  private readonly flPlayerHelper = inject(PlayerHelper);
-  private readonly flPlayers = injectPlayersByTurnOrder();
+  private readonly profitHelper = inject(ProfitHelper);
+  private readonly log = inject(Log);
+  private readonly playerHelper = inject(PlayerHelper);
+  private readonly shareHelper = inject(ShareHelper);
+  private readonly players = injectPlayersByTurnOrder();
 
   onStart(): void {
-    for (const player of this.flPlayers()) {
-      const expenses = this.flProfitHelper.getExpenses(player);
+    for (const player of this.players()) {
+      const expenses = this.profitHelper.getExpenses(player);
 
       if (player.money < expenses) {
         const deficit = expenses - player.money;
-        const sharesNeeded = Math.ceil(deficit / FORCED_SHARE_COST);
-
-        this.flPlayerHelper.update(player.color, (p) => {
-          p.shares += sharesNeeded;
-          p.money += FORCED_SHARE_COST * sharesNeeded;
-        });
-
-        this.flLog.player(
-          player,
-          `cannot afford expenses and is forced to issue ${sharesNeeded} share${sharesNeeded === 1 ? "" : "s"} at $${FORCED_SHARE_COST} each`,
+        const sharesNeeded = Math.min(
+          Math.ceil(deficit / SHARE_COST),
+          this.shareHelper.getMaxShares() - player.shares,
         );
-      }
 
-      const result = this.flMoneyManager.addMoney(player.color, -expenses, true);
+        if (sharesNeeded > 0) {
+          this.playerHelper.update(player.color, (p) => {
+            p.shares += sharesNeeded;
+            p.money += SHARE_COST * sharesNeeded;
+          });
 
-      if (result.lostIncome === 0) {
-        const profit = this.flProfitHelper.getProfit(player);
-        if (profit > 0) {
-          this.flLog.player(player, `earns $${profit}`);
-        } else {
-          this.flLog.player(player, `pays $${-profit} for expenses`);
-        }
-      } else {
-        this.flLog.player(
-          player,
-          `cannot afford expenses and loses ${result.lostIncome} income`,
-        );
-        if (result.outOfGame) {
-          this.flLog.player(player, `drops out of the game`);
+          this.log.player(
+            player,
+            `cannot afford expenses and is forced to issue ${sharesNeeded} share${sharesNeeded === 1 ? "" : "s"} at $${SHARE_COST} each`,
+          );
         }
       }
     }
+
+    super.onStart();
   }
 }

--- a/src/maps/four_loco/grid.ts
+++ b/src/maps/four_loco/grid.ts
@@ -1,0 +1,137 @@
+import { Good } from "../../engine/state/good";
+import {
+  city,
+  grid,
+  MOUNTAIN,
+  PLAIN,
+  town,
+  black,
+  white,
+  UNPASSABLE,
+} from "../factory";
+
+export const map = grid([
+  // Row 0
+  [
+    PLAIN,
+    city("Red Bull", Good.YELLOW, black(1), 3),
+    PLAIN,
+    PLAIN,
+    town("Full Throttle"),
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    city("Monster", Good.RED, black(4), 3),
+    PLAIN,
+  ],
+  // Row 1
+  [PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, town("Amp"), PLAIN, PLAIN, PLAIN],
+  // Row 2
+  [
+    PLAIN,
+    city("Bang", Good.BLUE, black(2), 3),
+    PLAIN,
+    town("Relentless"),
+    PLAIN,
+    city("Rockstar", Good.YELLOW, black(3), 3),
+    PLAIN,
+    PLAIN,
+    town("Venom"),
+    PLAIN,
+  ],
+  // Row 3
+  [
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    MOUNTAIN,
+    PLAIN,
+    town("Rip It"),
+    PLAIN,
+    PLAIN,
+    UNPASSABLE,
+  ],
+  // Row 4
+  [
+    PLAIN,
+    UNPASSABLE,
+    PLAIN,
+    PLAIN,
+    city("Reign", Good.RED, black(5), 3),
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+  ],
+  // Row 5
+  [
+    town("Guru"),
+    PLAIN,
+    town("Wired"),
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    city("Prime", Good.BLUE, black(6), 3),
+    PLAIN,
+    town("Volt"),
+    UNPASSABLE,
+  ],
+  // Row 6
+  [PLAIN, PLAIN, PLAIN, PLAIN, town("Burn"), PLAIN, PLAIN, PLAIN, PLAIN, PLAIN],
+  // Row 7
+  [
+    town("Spike"),
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    city("Celsius", Good.RED, white(6), 3),
+    UNPASSABLE,
+  ],
+  // Row 8
+  [
+    PLAIN,
+    PLAIN,
+    city("G Fuel", Good.RED, white(4), 3),
+    MOUNTAIN,
+    city("C4", Good.BLUE, white(5), 3),
+    PLAIN,
+    town("Sting"),
+    PLAIN,
+    PLAIN,
+    PLAIN,
+  ],
+  // Row 9
+  [PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, UNPASSABLE],
+  // Row 10
+  [
+    PLAIN,
+    town("5-hour Energy"),
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    city("NOS", Good.PURPLE, white(2), 3),
+    PLAIN,
+    PLAIN,
+    town("Emerge"),
+  ],
+  // Row 11
+  [
+    PLAIN,
+    PLAIN,
+    city("Ghost", Good.PURPLE, white(3), 3),
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    PLAIN,
+    city("Alani Nu", Good.BLUE, white(1), 3),
+    PLAIN,
+    UNPASSABLE,
+  ],
+]);

--- a/src/maps/four_loco/settings.ts
+++ b/src/maps/four_loco/settings.ts
@@ -1,5 +1,6 @@
 import { GameKey } from "../../api/game_key";
 import {
+  CHAD_DESHON,
   KAOSKODY,
   MapSettings,
   PlayerCountRating,
@@ -8,14 +9,18 @@ import {
 import { Module } from "../../engine/module/module";
 import { TurnLengthModule } from "../../modules/turn_length";
 import { map } from "./grid";
-import { FourLocoAllowedActions } from "./actions";
+import { FourLocoAllowedActions, FourLocoLocoAction } from "./actions";
 import {
   FourLocoMoveAction,
   FourLocoMovePassAction,
   FourLocoMovePhase,
   FourLocoMoveValidator,
 } from "./deliver";
-import { FourLocoExpensesPhase, FourLocoProfitHelper } from "./expenses";
+import {
+  FourLocoExpensesPhase,
+  FourLocoProfitHelper,
+  FourLocoTakeSharesAction,
+} from "./expenses";
 import { FourLocoStarter } from "./starter";
 
 /**
@@ -25,11 +30,12 @@ import { FourLocoStarter } from "./starter";
  * - All players start at engine level 4 (no Locomotive action)
  * - Exactly 4 links required per delivery
  * - Players may only use their own track for deliveries
- * - Delivery phase is unlimited rounds until all players pass consecutively
- * - Each delivery always awards exactly 2 income (regardless of path ownership)
+ * - Delivery phase continues until all players pass consecutively
+ *   (once a player passes, they are out until someone delivers, resetting passes)
+ * - Each delivery always awards exactly 2 income
  * - Engine level does NOT count toward expenses
- * - Normal share phase: $5 per share (base game behavior)
- * - Forced shares during expense phase: $3 per share (instead of income loss)
+ * - All shares cost $3 (both voluntary share phase and forced emergency shares)
+ * - Forced shares issued when player cannot afford expenses (up to share limit)
  * - Turn count: 2p→10, 3p→8, 4p→7, 5p→6, 6p→5
  */
 export class FourLocoMapSettings implements MapSettings {
@@ -51,7 +57,7 @@ export class FourLocoMapSettings implements MapSettings {
   };
   readonly startingGrid = map;
   readonly stage = ReleaseStage.DEVELOPMENT;
-  readonly developmentAllowlist = [KAOSKODY];
+  readonly developmentAllowlist = [KAOSKODY, CHAD_DESHON];
 
   getOverrides() {
     return [
@@ -60,8 +66,10 @@ export class FourLocoMapSettings implements MapSettings {
       FourLocoMoveAction,
       FourLocoMovePassAction,
       FourLocoMoveValidator,
+      FourLocoLocoAction,
       FourLocoProfitHelper,
       FourLocoExpensesPhase,
+      FourLocoTakeSharesAction,
       FourLocoAllowedActions,
     ];
   }

--- a/src/maps/four_loco/settings.ts
+++ b/src/maps/four_loco/settings.ts
@@ -42,7 +42,7 @@ export class FourLocoMapSettings implements MapSettings {
   readonly key = GameKey.FOUR_LOCO;
   readonly name = "4 Loco";
   readonly designer = "Chad DeShon";
-  readonly implementerId = KAOSKODY;
+  readonly implementerId = CHAD_DESHON;
   readonly minPlayers = 2;
   readonly maxPlayers = 6;
   readonly playerCountRatings = {

--- a/src/maps/four_loco/settings.ts
+++ b/src/maps/four_loco/settings.ts
@@ -1,0 +1,82 @@
+import { GameKey } from "../../api/game_key";
+import {
+  KAOSKODY,
+  MapSettings,
+  PlayerCountRating,
+  ReleaseStage,
+} from "../../engine/game/map_settings";
+import { Module } from "../../engine/module/module";
+import { TurnLengthModule } from "../../modules/turn_length";
+import { map } from "./grid";
+import { FourLocoAllowedActions } from "./actions";
+import {
+  FourLocoMoveAction,
+  FourLocoMovePassAction,
+  FourLocoMovePhase,
+  FourLocoMoveValidator,
+} from "./deliver";
+import { FourLocoExpensesPhase, FourLocoProfitHelper } from "./expenses";
+import { FourLocoStarter } from "./starter";
+
+/**
+ * 4 Loco Map Settings
+ *
+ * Custom rules:
+ * - All players start at engine level 4 (no Locomotive action)
+ * - Exactly 4 links required per delivery
+ * - Players may only use their own track for deliveries
+ * - Delivery phase is unlimited rounds until all players pass consecutively
+ * - Each delivery always awards exactly 2 income (regardless of path ownership)
+ * - Engine level does NOT count toward expenses
+ * - Normal share phase: $5 per share (base game behavior)
+ * - Forced shares during expense phase: $3 per share (instead of income loss)
+ * - Turn count: 2p→10, 3p→8, 4p→7, 5p→6, 6p→5
+ */
+export class FourLocoMapSettings implements MapSettings {
+  readonly key = GameKey.FOUR_LOCO;
+  readonly name = "4 Loco";
+  readonly designer = "Chad DeShon";
+  readonly implementerId = KAOSKODY;
+  readonly minPlayers = 2;
+  readonly maxPlayers = 6;
+  readonly playerCountRatings = {
+    1: PlayerCountRating.NOT_SUPPORTED,
+    2: PlayerCountRating.NOT_RECOMMENDED,
+    3: PlayerCountRating.RECOMMENDED,
+    4: PlayerCountRating.HIGHLY_RECOMMENDED,
+    5: PlayerCountRating.RECOMMENDED,
+    6: PlayerCountRating.NOT_RECOMMENDED,
+    7: PlayerCountRating.NOT_SUPPORTED,
+    8: PlayerCountRating.NOT_SUPPORTED,
+  };
+  readonly startingGrid = map;
+  readonly stage = ReleaseStage.DEVELOPMENT;
+  readonly developmentAllowlist = [KAOSKODY];
+
+  getOverrides() {
+    return [
+      FourLocoStarter,
+      FourLocoMovePhase,
+      FourLocoMoveAction,
+      FourLocoMovePassAction,
+      FourLocoMoveValidator,
+      FourLocoProfitHelper,
+      FourLocoExpensesPhase,
+      FourLocoAllowedActions,
+    ];
+  }
+
+  getModules(): Array<Module> {
+    return [
+      new TurnLengthModule({
+        function: (playerCount: number) => {
+          if (playerCount === 2) return 10;
+          if (playerCount === 3) return 8;
+          if (playerCount === 4) return 7;
+          if (playerCount === 5) return 6;
+          return 5; // 6+ players
+        },
+      }),
+    ];
+  }
+}

--- a/src/maps/four_loco/starter.ts
+++ b/src/maps/four_loco/starter.ts
@@ -1,0 +1,12 @@
+import { GameStarter } from "../../engine/game/starter";
+import { PlayerColor, PlayerData } from "../../engine/state/player";
+
+export class FourLocoStarter extends GameStarter {
+  protected buildPlayer(playerId: number, color: PlayerColor): PlayerData {
+    return {
+      ...super.buildPlayer(playerId, color),
+      // All players start at engine level 4
+      locomotive: 4,
+    };
+  }
+}

--- a/src/maps/four_loco/view_settings.tsx
+++ b/src/maps/four_loco/view_settings.tsx
@@ -1,0 +1,62 @@
+import { ReactNode } from "react";
+import { Button } from "semantic-ui-react";
+import { MovePassAction } from "../../engine/move/pass";
+import { Phase } from "../../engine/state/phase";
+import { Username } from "../../client/components/username";
+import { useEmptyAction } from "../../client/services/action";
+import { GenericMessage } from "../../client/game/action_summary";
+import { MapViewSettings } from "../view_settings";
+import { FourLocoMapSettings } from "./settings";
+
+function FourLocoMoveGoods() {
+  const { emit: emitPass, canEmit, canEmitUserId } =
+    useEmptyAction(MovePassAction);
+
+  if (canEmitUserId == null) {
+    return <></>;
+  }
+
+  if (!canEmit) {
+    return (
+      <GenericMessage>
+        <Username userId={canEmitUserId} /> must move a good or pass.
+      </GenericMessage>
+    );
+  }
+
+  return (
+    <div>
+      <GenericMessage>You must move a good or pass.</GenericMessage>
+      <Button negative onClick={emitPass}>
+        Pass
+      </Button>
+    </div>
+  );
+}
+
+export class FourLocoViewSettings
+  extends FourLocoMapSettings
+  implements MapViewSettings
+{
+  getMapRules() {
+    return (
+      <ul>
+        <li>All players start at engine level 4. No Locomotive action.</li>
+        <li>Each delivery must use exactly 4 links.</li>
+        <li>Players may only use their own track.</li>
+        <li>Delivery phase repeats until all players pass consecutively.</li>
+        <li>Every delivery awards exactly 2 income.</li>
+        <li>Engine level is excluded from expenses.</li>
+        <li>Shares cost $3 each.</li>
+        <li>Turns: 2p→10, 3p→8, 4p→7, 5p→6, 6p→5.</li>
+      </ul>
+    );
+  }
+
+  getActionSummary(phase: Phase | undefined): (() => ReactNode) | undefined {
+    if (phase === Phase.MOVING) {
+      return FourLocoMoveGoods;
+    }
+    return undefined;
+  }
+}

--- a/src/maps/registry.ts
+++ b/src/maps/registry.ts
@@ -47,6 +47,7 @@ import { DoubleBaseUsaMapSettings } from "./double_base_usa/settings";
 import { ChicagoLMapSettings } from "./chicago-l/settings";
 import { MinasGeraesMapSettings } from "./minas-geraes/settings";
 import { JapanMapSettings } from "./japan/settings";
+import { FourLocoMapSettings } from "./four_loco/settings";
 
 export class MapRegistry {
   static readonly singleton = new MapRegistry();
@@ -99,6 +100,7 @@ export class MapRegistry {
     this.add(new ChicagoLMapSettings());
     this.add(new MinasGeraesMapSettings());
     this.add(new JapanMapSettings());
+    this.add(new FourLocoMapSettings());
   }
 
   values(): Iterable<MapSettings> {

--- a/src/maps/view_registry.ts
+++ b/src/maps/view_registry.ts
@@ -47,6 +47,7 @@ import { DoubleBaseUsaViewSettings } from "./double_base_usa/view_settings";
 import { ChicagoLViewSettings } from "./chicago-l/view_settings";
 import { MinasGeraesViewSettings } from "./minas-geraes/view_settings";
 import { JapanViewSettings } from "./japan/view_settings";
+import { FourLocoViewSettings } from "./four_loco/view_settings";
 
 export class ViewRegistry {
   static readonly singleton = new ViewRegistry();
@@ -99,6 +100,7 @@ export class ViewRegistry {
     this.add(new ChicagoLViewSettings());
     this.add(new MinasGeraesViewSettings());
     this.add(new JapanViewSettings());
+    this.add(new FourLocoViewSettings());
   }
 
   values(): Iterable<MapViewSettings> {


### PR DESCRIPTION
# 4 Loco Map — Pull Request

## Overview

This PR adds a new map called **"4 Loco"** (designed by Chad DeShon) as a development-stage map to the choochoo platform.

## Files Changed

### New Files
- `src/maps/four_loco/grid.ts` — Board layout (hex grid with 12 cities and 13 town spots, all named after energy drink brands)
- `src/maps/four_loco/starter.ts` — All players start at engine level 4
- `src/maps/four_loco/deliver.ts` — Custom delivery phase logic (unlimited rounds, own-track-only, always 2 income)
- `src/maps/four_loco/expenses.ts` — Engine level excluded from expenses; forced share issuance at $3 when player can't afford expenses
- `src/maps/four_loco/actions.ts` — Locomotive action removed from action selection
- `src/maps/four_loco/settings.ts` — Map configuration and module wiring
- `src/maps/four_loco/view_settings.tsx` — View configuration

### Modified Files
- `src/api/game_key.ts` — Added `FOUR_LOCO = "four-loco"` enum value
- `src/api/variant_config.ts` — Added `GameKey.FOUR_LOCO` to `EmptyVariantConfig`
- `src/maps/registry.ts` — Registered `FourLocoMapSettings`
- `src/maps/view_registry.ts` — Registered `FourLocoViewSettings`

## Custom Rules Implemented

| Rule | Implementation |
|------|---------------|
| Engine level 4 start | `FourLocoStarter.buildPlayer()` sets `locomotive: 4` |
| No Locomotive action | `FourLocoAllowedActions.getActions()` removes `Action.LOCOMOTIVE` |
| Exactly 4 links per delivery | `FourLocoMoveValidator.validateEnd()` asserts `path.length === 4` |
| Own track only | `FourLocoMoveValidator.findRoutesFromLocation()` checks all tiles via `grid.getRoute()` |
| Unlimited delivery rounds until all pass consecutively | `FourLocoMovePhase.findNextPlayer()` cycles until all players appear in `passedPlayers` list |
| Always 2 income per delivery | `FourLocoMoveAction.calculateIncome()` always returns `{ currentPlayer: 2 }` |
| Engine excluded from expenses | `FourLocoProfitHelper.getExpenses()` returns `player.shares` only |
| Forced shares at $3 when player can't afford expenses | `FourLocoExpensesPhase.onStart()` issues shares at $3 each before deducting expenses (voluntary shares in the share phase remain $5) |
| Turn length by player count | `TurnLengthModule({ function: n => n===2?10:n===3?8:n===4?7:n===5?6:5 })` |

## Map Layout

- 12 cities named after energy drink brands (Red Bull, Monster, Bang, Rockstar, Reign, Prime, Celsius, G Fuel, C4, NOS, Ghost, Alani Nu)
- 13 towns named after secondary brands (Full Throttle, Amp, Relentless, Venom, Rip It, Guru, Wired, Volt, Burn, Spike, Sting, 5-hour Energy, Emerge)

## Notes

- The map is in `ReleaseStage.DEVELOPMENT`
- The `developmentAllowlist` in `settings.ts` uses `[KAOSKODY]` — the implementer can add additional user IDs as needed
- Cities with two dice rolls (e.g., `[black(5), black(6)]`) have goods growth on both roll values
