### PR TITLE
Fix 4 Loco grid: adjust PLAIN/UNPASSABLE cells in rows 1 and 5

### DIFF
--- a/src/maps/four_loco/grid.ts
+++ b/src/maps/four_loco/grid.ts
@@ -25,7 +25,7 @@ export const map = grid([
     PLAIN,
   ],
   // Row 1
-  [PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, town("Amp"), PLAIN, PLAIN, PLAIN],
+  [PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, PLAIN, town("Amp"), PLAIN, PLAIN, UNPASSABLE],
   // Row 2
   [
     PLAIN,
@@ -55,7 +55,7 @@ export const map = grid([
   // Row 4
   [
     PLAIN,
-    UNPASSABLE,
+    PLAIN,
     PLAIN,
     PLAIN,
     city("Reign", Good.RED, black(5), 3),


### PR DESCRIPTION
Small follow-up to #254 — adjusts two cells in the 4 Loco grid that were swapped incorrectly:

  - Row 1 (Amp town row): last cell changed from `PLAIN` → `UNPASSABLE`
  - Row 5: index 1 cell changed from `UNPASSABLE` → `PLAIN`