### PR TITLE
Observer refactor

### DIFF
--- a/src/client/services/game.ts
+++ b/src/client/services/game.ts
@@ -406,8 +406,7 @@ export function useLeaveGame(game: GameLiteApi): GameAction {
   const canPerform =
     me != null &&
     game.status == GameStatus.enum.LOBBY &&
-    game.playerIds.includes(me.id) &&
-    game.ownerId !== me.id;
+    game.playerIds.includes(me.id);
 
   return { canPerform, perform, isPending };
 }

--- a/src/server/game/routes.ts
+++ b/src/server/game/routes.ts
@@ -245,8 +245,6 @@ const router = initServer().router(gameContract, {
     assert(game.status === GameStatus.enum.LOBBY, "cannot leave started game");
     const index = game.playerIds.indexOf(userId);
     assert(index >= 0, { invalidInput: "cannot leave game you are not in" });
-    // Figure out what to do if the owner wants to leave
-    assert(index > 0, { invalidInput: "the owner cannot leave the game" });
 
     game.playerIds = game.playerIds
       .slice(0, index)


### PR DESCRIPTION
Stacked PR on #258 . Allows a table owner to leave their own table, effectively making them an observer. Unlikely to be a common flow, but useful for map developers who want to be able to watch a playtest without participating in it.