### PR TITLE
Browser Tab Indicator for Active Games (#224)

### DIFF
--- a/src/client/components/awaiting_player.tsx
+++ b/src/client/components/awaiting_player.tsx
@@ -1,48 +1,64 @@
-import {
-  createContext,
-  ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useReducer,
-} from "react";
+import { createContext, ReactNode, useContext, useEffect, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { GamePageCursor } from "../../api/game";
+import { tsr } from "../services/client";
+import { useJoinRoom, useSocket } from "../services/socket";
 import { useMe } from "../services/me";
 
-const AwaitingPlayerContext = createContext<(() => void) | undefined>(
-  undefined,
-);
-const IsAwaitingPlayerContext = createContext(false);
+const AwaitingGameIdsContext = createContext<Set<number>>(new Set());
 
-export function useAwaitingPlayer(awaitingPlayer?: number): void {
-  const me = useMe();
-  const ctx = useContext(AwaitingPlayerContext);
-  useEffect(() => {
-    if (ctx != null && awaitingPlayer != null && awaitingPlayer === me?.id) {
-      return ctx();
-    }
-  }, [me?.id, awaitingPlayer, ctx]);
-}
-
-export function useIsAwaitingPlayer(): boolean {
-  return useContext(IsAwaitingPlayerContext);
+export function useAwaitingGameIds(): Set<number> {
+  return useContext(AwaitingGameIdsContext);
 }
 
 export function AwaitingContextProvider({ children }: { children: ReactNode }) {
-  const [numAwaiting, incrNumAwaiting] = useReducer(
-    (prev: number, incr: number) => prev + incr,
-    0,
-  );
-  const increment = useCallback(() => {
-    incrNumAwaiting(1);
+  const me = useMe();
+  const socket = useSocket();
+  const queryClient = useQueryClient();
+
+  useJoinRoom();
+
+  const queryKey = useMemo(() => ["awaitingGames", me?.id], [me?.id]);
+
+  const { data } = tsr.games.list.useInfiniteQuery({
+    queryKey,
+    queryData: ({ pageParam }) => ({
+      query: {
+        status: ["ACTIVE"],
+        userId: me?.id,
+        pageCursor: pageParam,
+      },
+    }),
+    initialPageParam: undefined as GamePageCursor | undefined,
+    getNextPageParam: () => undefined,
+    enabled: me != null,
+  });
+
+  const awaitingGameIds = useMemo(() => {
+    if (!data || !me) return new Set<number>();
+    const games = data.pages[0]?.body?.games ?? [];
+    return new Set(
+      games
+        .filter((game) => game.activePlayerId === me.id)
+        .map((game) => game.id),
+    );
+  }, [data, me]);
+
+  useEffect(() => {
+    function handleGameUpdate() {
+      queryClient.invalidateQueries({ queryKey });
+    }
+    socket.on("gameUpdateLite", handleGameUpdate);
+    socket.on("gameDestroy", handleGameUpdate);
     return () => {
-      incrNumAwaiting(-1);
+      socket.off("gameUpdateLite", handleGameUpdate);
+      socket.off("gameDestroy", handleGameUpdate);
     };
-  }, [numAwaiting, incrNumAwaiting]);
+  }, [queryKey, queryClient, socket]);
+
   return (
-    <AwaitingPlayerContext.Provider value={increment}>
-      <IsAwaitingPlayerContext.Provider value={numAwaiting > 0}>
-        {children}
-      </IsAwaitingPlayerContext.Provider>
-    </AwaitingPlayerContext.Provider>
+    <AwaitingGameIdsContext.Provider value={awaitingGameIds}>
+      {children}
+    </AwaitingGameIdsContext.Provider>
   );
 }

--- a/src/client/game/active_game.tsx
+++ b/src/client/game/active_game.tsx
@@ -5,7 +5,6 @@ import { ProductionAction } from "../../engine/goods_growth/production";
 import { SelectAction } from "../../engine/select_action/select";
 import { ViewRegistry } from "../../maps/view_registry";
 import { AutoActionForm } from "../auto_action/form";
-import { useAwaitingPlayer } from "../components/awaiting_player";
 import { Username } from "../components/username";
 import { GameMap } from "../grid/game_map";
 import { DeleteButton } from "../home/game_card";
@@ -51,8 +50,6 @@ function InternalActiveGame() {
   const game = useGame();
   const [searchParams] = useSearchParams();
   const undoOnly = searchParams.get("undoOnly") != null;
-
-  useAwaitingPlayer(game.activePlayerId);
 
   return (
     <div>

--- a/src/client/home/game_card.tsx
+++ b/src/client/home/game_card.tsx
@@ -17,7 +17,6 @@ import {
 } from "../../api/game";
 import { ViewRegistry } from "../../maps/view_registry";
 import { assertNever } from "../../utils/validate";
-import { useAwaitingPlayer } from "../components/awaiting_player";
 import { Username, UsernameList } from "../components/username";
 import {
   useDeleteGame,
@@ -35,8 +34,6 @@ interface GameCardProps {
 
 export function GameCard({ game, hideStatus }: GameCardProps) {
   const me = useMe();
-
-  useAwaitingPlayer(game.activePlayerId);
 
   const variantString = ViewRegistry.singleton
     .get(game.gameKey)

--- a/src/client/root/app.tsx
+++ b/src/client/root/app.tsx
@@ -30,15 +30,15 @@ export function App() {
         <SocketContextProvider>
           <ThemeProvider>
             <DialogsProvider>
-              <AwaitingContextProvider>
-                <QueryClientProvider client={queryClient}>
+              <QueryClientProvider client={queryClient}>
                   <tsr.ReactQueryProvider>
                     <AdminModeProvider>
-                      <Router />
+                      <AwaitingContextProvider>
+                        <Router />
+                      </AwaitingContextProvider>
                     </AdminModeProvider>
                   </tsr.ReactQueryProvider>
                 </QueryClientProvider>
-              </AwaitingContextProvider>
             </DialogsProvider>
           </ThemeProvider>
         </SocketContextProvider>

--- a/src/client/root/layout.tsx
+++ b/src/client/root/layout.tsx
@@ -15,6 +15,7 @@ import {
   useMe,
 } from "../services/me";
 import { isNetworkError } from "../services/network";
+import { useTabIndicator } from "../services/tab_indicator";
 import { Banner } from "./banner";
 import * as styles from "./layout.module.css";
 import { useTheme } from "./theme";
@@ -31,6 +32,9 @@ export function Layout() {
   const [enableAdminMode, setEnableAdminMode] = useEnableAdminMode();
   const isAdmin = useIsAdmin(true);
   const isAwaiting = useIsAwaitingPlayer();
+
+  // Update browser tab indicator with count of games awaiting user's turn
+  useTabIndicator();
 
   useEffect(() => {
     document.body.classList.toggle("dark-mode", isDarkMode);

--- a/src/client/root/layout.tsx
+++ b/src/client/root/layout.tsx
@@ -1,9 +1,9 @@
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet, useParams } from "react-router-dom";
 import { cssTransition, ToastContainer } from "react-toastify";
 import { Button, Dropdown, Icon, Menu, MenuMenu } from "semantic-ui-react";
-import { useIsAwaitingPlayer } from "../components/awaiting_player";
+import { useAwaitingGameIds } from "../components/awaiting_player";
 import { Loading } from "../components/loading";
 import { environment } from "../services/environment";
 import { FeedbackForm } from "../services/feedback/form";
@@ -31,7 +31,12 @@ export function Layout() {
 
   const [enableAdminMode, setEnableAdminMode] = useEnableAdminMode();
   const isAdmin = useIsAdmin(true);
-  const isAwaiting = useIsAwaitingPlayer();
+  const { gameId } = useParams();
+  const awaitingGameIds = useAwaitingGameIds();
+  const isAwaiting =
+    gameId != null
+      ? awaitingGameIds.has(Number(gameId))
+      : awaitingGameIds.size > 0;
 
   // Update browser tab indicator with count of games awaiting user's turn
   useTabIndicator();

--- a/src/client/services/tab_indicator.tsx
+++ b/src/client/services/tab_indicator.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { tsr } from "./client";
+import { useJoinRoom, useSocket } from "./socket";
+import { useMe } from "./me";
+
+/**
+ * Generates a favicon with a badge by compositing the original favicon image
+ * with a badge overlay using Canvas when the count is greater than zero.
+ */
+async function generateFaviconWithBadge(count: number): Promise<string> {
+  if (count === 0) {
+    // Return base favicon path
+    return "/favicon.ico";
+  }
+
+  try {
+    // Get the original favicon
+    const faviconLink = document.querySelector(
+      'link[rel="icon"]',
+    ) as HTMLLinkElement | null;
+    const faviconSrc = faviconLink?.href || "/favicon.ico";
+
+    // Create a canvas to composite the favicon and badge
+    const canvas = document.createElement("canvas");
+    canvas.width = 32;
+    canvas.height = 32;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Failed to get canvas context");
+
+    // Load and draw the original favicon
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => {
+        // Draw favicon
+        ctx.drawImage(img, 0, 0, 32, 32);
+
+        // Draw orangered hexagon badge in the top-left corner (matches appBarActive color)
+        ctx.fillStyle = "orangered";
+        ctx.beginPath();
+        const hexCenterX = 8;
+        const hexCenterY = 8;
+        const hexRadius = 8;
+        for (let i = 0; i < 6; i++) {
+          const angle = (i * Math.PI) / 3; // 60 degrees between points
+          const x = hexCenterX + hexRadius * Math.cos(angle);
+          const y = hexCenterY + hexRadius * Math.sin(angle);
+          if (i === 0) {
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+        ctx.closePath();
+        ctx.fill();
+
+        // Draw badge border
+        ctx.strokeStyle = "white";
+        ctx.lineWidth = 2;
+        ctx.stroke();
+
+        resolve();
+      };
+      img.onerror = reject;
+      img.src = faviconSrc;
+    });
+
+    // Convert canvas to data URL
+    return canvas.toDataURL("image/png");
+  } catch (error) {
+    // Fallback: return base favicon if compositing fails
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.error(
+        "Failed to generate favicon with badge; using fallback favicon instead.",
+        error,
+      );
+    }
+    return "/favicon.ico";
+  }
+}
+
+/**
+ * Monitors active games where it's the user's turn and updates the browser tab
+ * title and favicon badge accordingly. Integrates with WebSocket for real-time updates.
+ */
+export function useTabIndicator(): void {
+  const me = useMe();
+  const socket = useSocket();
+  const queryClient = useQueryClient();
+
+  // Join home room to receive game list updates
+  useJoinRoom();
+
+  // Construct query with consistent pattern (sorted entries)
+  const query = useMemo(
+    () => ({
+      status: ["ACTIVE"] as ("LOBBY" | "ACTIVE" | "ENDED" | "ABANDONED")[],
+      userId: me?.id,
+    }),
+    [me?.id],
+  );
+
+  const queryKeyFromFilter = Object.entries(query)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([key, value]) =>
+      Array.isArray(value)
+        ? `${key}:${value.join(",")}`
+        : `${key}:${value}`,
+    )
+    .join(",");
+
+  const queryKey = ["gameList", queryKeyFromFilter];
+
+  // Query for active games only
+  const { data } = tsr.games.list.useInfiniteQuery({
+    queryKey,
+    queryData: ({ pageParam }) => ({
+      query: { ...query, pageCursor: pageParam },
+    }),
+    initialPageParam: undefined,
+    getNextPageParam: () => undefined, // Only fetch first page
+    enabled: me != null,
+  });
+
+  const gameCount = useMemo(() => {
+    if (!data || !me) return 0;
+
+    // Get all games from the first page
+    const games = data.pages[0]?.body?.games ?? [];
+
+    // Count only games where activePlayerId matches the current user
+    return games.filter((game) => game.activePlayerId === me.id).length;
+  }, [data, me]);
+
+  // Update document title and favicon
+  useEffect(() => {
+    if (gameCount > 0) {
+      document.title = `Choo Choo Games - Your Turn in ${gameCount} Game${gameCount === 1 ? "" : "s"}`;
+    } else {
+      document.title = "Choo Choo Games";
+    }
+
+    // Update favicon asynchronously
+    let cancelled = false;
+
+    const updateFavicon = async () => {
+      const faviconHref = await generateFaviconWithBadge(gameCount);
+
+      if (cancelled) return;
+
+      const faviconLink = document.querySelector(
+        'link[rel="icon"]',
+      ) as HTMLLinkElement | null;
+
+      if (faviconLink) {
+        faviconLink.href = faviconHref;
+      } else {
+        // Create favicon link if it doesn't exist
+        const link = document.createElement("link");
+        link.rel = "icon";
+        link.href = faviconHref;
+        document.head.appendChild(link);
+      }
+    };
+
+    updateFavicon();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [gameCount]);
+
+  // WebSocket event listeners for real-time updates
+  useEffect(() => {
+    function handleGameUpdate() {
+      // Refetch query when game updates occur
+      queryClient.invalidateQueries({ queryKey });
+    }
+
+    socket.on("gameUpdateLite", handleGameUpdate);
+    socket.on("gameDestroy", handleGameUpdate);
+
+    return () => {
+      socket.off("gameUpdateLite", handleGameUpdate);
+      socket.off("gameDestroy", handleGameUpdate);
+    };
+  }, [queryKey, queryClient, socket]);
+
+}

--- a/src/client/services/tab_indicator.tsx
+++ b/src/client/services/tab_indicator.tsx
@@ -1,27 +1,17 @@
-import { useEffect, useMemo } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { tsr } from "./client";
-import { useJoinRoom, useSocket } from "./socket";
-import { useMe } from "./me";
+import { useEffect } from "react";
+import { useAwaitingGameIds } from "../components/awaiting_player";
 
-/**
- * Generates a favicon with a badge by compositing the original favicon image
- * with a badge overlay using Canvas when the count is greater than zero.
- */
 async function generateFaviconWithBadge(count: number): Promise<string> {
   if (count === 0) {
-    // Return base favicon path
     return "/favicon.ico";
   }
 
   try {
-    // Get the original favicon
     const faviconLink = document.querySelector(
       'link[rel="icon"]',
     ) as HTMLLinkElement | null;
     const faviconSrc = faviconLink?.href || "/favicon.ico";
 
-    // Create a canvas to composite the favicon and badge
     const canvas = document.createElement("canvas");
     canvas.width = 32;
     canvas.height = 32;
@@ -29,13 +19,11 @@ async function generateFaviconWithBadge(count: number): Promise<string> {
     const ctx = canvas.getContext("2d");
     if (!ctx) throw new Error("Failed to get canvas context");
 
-    // Load and draw the original favicon
     const img = new Image();
     img.crossOrigin = "anonymous";
 
     await new Promise<void>((resolve, reject) => {
       img.onload = () => {
-        // Draw favicon
         ctx.drawImage(img, 0, 0, 32, 32);
 
         // Draw orangered hexagon badge in the top-left corner (matches appBarActive color)
@@ -45,7 +33,7 @@ async function generateFaviconWithBadge(count: number): Promise<string> {
         const hexCenterY = 8;
         const hexRadius = 8;
         for (let i = 0; i < 6; i++) {
-          const angle = (i * Math.PI) / 3; // 60 degrees between points
+          const angle = (i * Math.PI) / 3;
           const x = hexCenterX + hexRadius * Math.cos(angle);
           const y = hexCenterY + hexRadius * Math.sin(angle);
           if (i === 0) {
@@ -57,7 +45,6 @@ async function generateFaviconWithBadge(count: number): Promise<string> {
         ctx.closePath();
         ctx.fill();
 
-        // Draw badge border
         ctx.strokeStyle = "white";
         ctx.lineWidth = 2;
         ctx.stroke();
@@ -68,10 +55,8 @@ async function generateFaviconWithBadge(count: number): Promise<string> {
       img.src = faviconSrc;
     });
 
-    // Convert canvas to data URL
     return canvas.toDataURL("image/png");
   } catch (error) {
-    // Fallback: return base favicon if compositing fails
     if (process.env.NODE_ENV !== "production") {
       // eslint-disable-next-line no-console
       console.error(
@@ -83,73 +68,20 @@ async function generateFaviconWithBadge(count: number): Promise<string> {
   }
 }
 
-/**
- * Monitors active games where it's the user's turn and updates the browser tab
- * title and favicon badge accordingly. Integrates with WebSocket for real-time updates.
- */
 export function useTabIndicator(): void {
-  const me = useMe();
-  const socket = useSocket();
-  const queryClient = useQueryClient();
+  const count = useAwaitingGameIds().size;
 
-  // Join home room to receive game list updates
-  useJoinRoom();
-
-  // Construct query with consistent pattern (sorted entries)
-  const query = useMemo(
-    () => ({
-      status: ["ACTIVE"] as ("LOBBY" | "ACTIVE" | "ENDED" | "ABANDONED")[],
-      userId: me?.id,
-    }),
-    [me?.id],
-  );
-
-  const queryKeyFromFilter = Object.entries(query)
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([key, value]) =>
-      Array.isArray(value)
-        ? `${key}:${value.join(",")}`
-        : `${key}:${value}`,
-    )
-    .join(",");
-
-  const queryKey = ["gameList", queryKeyFromFilter];
-
-  // Query for active games only
-  const { data } = tsr.games.list.useInfiniteQuery({
-    queryKey,
-    queryData: ({ pageParam }) => ({
-      query: { ...query, pageCursor: pageParam },
-    }),
-    initialPageParam: undefined,
-    getNextPageParam: () => undefined, // Only fetch first page
-    enabled: me != null,
-  });
-
-  const gameCount = useMemo(() => {
-    if (!data || !me) return 0;
-
-    // Get all games from the first page
-    const games = data.pages[0]?.body?.games ?? [];
-
-    // Count only games where activePlayerId matches the current user
-    return games.filter((game) => game.activePlayerId === me.id).length;
-  }, [data, me]);
-
-  // Update document title and favicon
   useEffect(() => {
-    if (gameCount > 0) {
-      document.title = `Choo Choo Games - Your Turn in ${gameCount} Game${gameCount === 1 ? "" : "s"}`;
+    if (count > 0) {
+      document.title = `Choo Choo Games - Your Turn in ${count} Game${count === 1 ? "" : "s"}`;
     } else {
       document.title = "Choo Choo Games";
     }
 
-    // Update favicon asynchronously
     let cancelled = false;
 
     const updateFavicon = async () => {
-      const faviconHref = await generateFaviconWithBadge(gameCount);
-
+      const faviconHref = await generateFaviconWithBadge(count);
       if (cancelled) return;
 
       const faviconLink = document.querySelector(
@@ -159,7 +91,6 @@ export function useTabIndicator(): void {
       if (faviconLink) {
         faviconLink.href = faviconHref;
       } else {
-        // Create favicon link if it doesn't exist
         const link = document.createElement("link");
         link.rel = "icon";
         link.href = faviconHref;
@@ -172,22 +103,5 @@ export function useTabIndicator(): void {
     return () => {
       cancelled = true;
     };
-  }, [gameCount]);
-
-  // WebSocket event listeners for real-time updates
-  useEffect(() => {
-    function handleGameUpdate() {
-      // Refetch query when game updates occur
-      queryClient.invalidateQueries({ queryKey });
-    }
-
-    socket.on("gameUpdateLite", handleGameUpdate);
-    socket.on("gameDestroy", handleGameUpdate);
-
-    return () => {
-      socket.off("gameUpdateLite", handleGameUpdate);
-      socket.off("gameDestroy", handleGameUpdate);
-    };
-  }, [queryKey, queryClient, socket]);
-
+  }, [count]);
 }


### PR DESCRIPTION
This PR rebases @lordscarlet 's prior PR #227 and then adds an additional commit on top to refactor the changes so that the tab indicator, the current game page, and the layout for all other pages all share the same useIsAwaitingPlayer context, so that we retain a single source of truth and a single query for all of these indicators. I validated that all of these indicators still have event-based updates when it becomes the player's turn.