### PR TITLE
Refactor variant config to break import cycles.

### DIFF
--- a/src/api/game.ts
+++ b/src/api/game.ts
@@ -73,9 +73,16 @@ export const CreateGameApi = z
     autoStart: z.boolean(),
   })
   .and(MapConfig)
-  .refine((data) => data.gameKey === data.variant.gameKey, {
-    message: "Game key does not match",
-  })
+  .refine(
+    (data) => {
+      const { variantConfig } = MapRegistry.singleton.get(data.gameKey);
+      if (variantConfig == null) {
+        return Object.keys(data.variant).length === 0;
+      }
+      return variantConfig.safeParse(data.variant).success;
+    },
+    { message: "Invalid variant config", path: ["variant"] },
+  )
   .refine((data) => data.minPlayers <= data.maxPlayers, {
     message: "Cannot be less than min players",
     path: ["maxPlayers"],

--- a/src/api/variant_config.ts
+++ b/src/api/variant_config.ts
@@ -1,40 +1,4 @@
 import z from "zod";
-import { GameKeyZod } from "./game_key";
-import { IRELAND_GAME_KEY } from "../maps/ireland/key";
-import { REVERSTEAM_GAME_KEY } from "../maps/reversteam/key";
-import { CYPRUS_GAME_KEY } from "../maps/cyprus/key";
-import { PUERTO_RICO_GAME_KEY } from "../maps/puerto_rico/key";
-import { DIFFICULTY_LEVELS } from "../maps/puerto_rico/difficulty_levels";
 
-export const IrelandVariantConfig = z.object({
-  gameKey: z.literal(IRELAND_GAME_KEY),
-  locoVariant: z.boolean(),
-});
-export type IrelandVariantConfig = z.infer<typeof IrelandVariantConfig>;
-
-export const ReversteamVariantConfig = z.object({
-  gameKey: z.literal(REVERSTEAM_GAME_KEY),
-  baseRules: z.boolean(),
-});
-export type ReversteamVariantConfig = z.infer<typeof ReversteamVariantConfig>;
-
-export const CyprusVariantConfig = z.object({
-  gameKey: z.literal(CYPRUS_GAME_KEY),
-  variant2020: z.boolean().optional(),
-});
-export type CyprusVariantConfig = z.infer<typeof CyprusVariantConfig>;
-
-export const PuertoRicoVariantConfig = z.object({
-  gameKey: z.literal(PUERTO_RICO_GAME_KEY),
-  difficulty: z.enum([...DIFFICULTY_LEVELS]),
-});
-export type PuertoRicoVariantConfig = z.infer<typeof PuertoRicoVariantConfig>;
-
-export const VariantConfig = z.union([
-  IrelandVariantConfig,
-  ReversteamVariantConfig,
-  CyprusVariantConfig,
-  PuertoRicoVariantConfig,
-  z.object({ gameKey: GameKeyZod }),
-]);
+export const VariantConfig = z.record(z.unknown());
 export type VariantConfig = z.infer<typeof VariantConfig>;

--- a/src/client/components/pallet.tsx
+++ b/src/client/components/pallet.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { REVERSTEAM_GAME_KEY } from "../../maps/reversteam/key";
+import { REVERSTEAM_GAME_KEY } from "../../maps/reversteam/settings";
 import { Land } from "../../engine/map/location";
 import { SpaceType } from "../../engine/state/location_type";
 import { allPlayerColors } from "../../engine/state/player";

--- a/src/client/game/create_page.tsx
+++ b/src/client/game/create_page.tsx
@@ -83,7 +83,7 @@ export function CreateGamePage() {
   const { validateGame, createGame, validationError, isPending } =
     useCreateGame();
   const [variant, setVariant] = useState(
-    (selectedMap.getInitialVariantConfig?.() ?? { gameKey }) as VariantConfig,
+    (selectedMap.getInitialVariantConfig?.() ?? {}) as VariantConfig,
   );
   const isAdmin = useIsAdmin();
   const [mapDialogOpen, setMapDialogOpen] = useState(false);
@@ -101,9 +101,7 @@ export function CreateGamePage() {
       if (typeof maxPlayers === "number") {
         setMaxPlayersRaw(Math.min(maxPlayers, map.maxPlayers));
       }
-      setVariant(
-        (map.getInitialVariantConfig?.() ?? { gameKey }) as VariantConfig,
-      );
+      setVariant((map.getInitialVariantConfig?.() ?? {}) as VariantConfig);
     },
     [
       setVariant,

--- a/src/client/game/player_stats.tsx
+++ b/src/client/game/player_stats.tsx
@@ -11,7 +11,7 @@ import { MoveHelper } from "../../engine/move/helper";
 import { ActionNamingProvider } from "../../engine/state/action";
 import { PlayerColor, PlayerData } from "../../engine/state/player";
 import { countryName } from "../../maps/cyprus/roles";
-import { CYPRUS_GAME_KEY } from "../../maps/cyprus/key";
+import { CYPRUS_GAME_KEY } from "../../maps/cyprus/settings";
 import { Incinerator } from "../../maps/sweden/incinerator";
 import { SwedenRecyclingMapSettings } from "../../maps/sweden/settings";
 import { getPlayerColorCss } from "../components/player_color";

--- a/src/e2e/build_track_test.ts
+++ b/src/e2e/build_track_test.ts
@@ -1,4 +1,4 @@
-import { REVERSTEAM_GAME_KEY } from "../maps/reversteam/key";
+import { REVERSTEAM_GAME_KEY } from "../maps/reversteam/settings";
 import { Direction, SimpleTileType, TownTileType } from "../engine/state/tile";
 import { Coordinates } from "../utils/coordinates";
 import { compareGameData, setUpGameEnvironment } from "./util/game_data";
@@ -6,7 +6,8 @@ import { Driver } from "./util/webdriver";
 
 export function buildingTrack(driver: Driver) {
   const env = setUpGameEnvironment(
-    { gameKey: REVERSTEAM_GAME_KEY, baseRules: true },
+    REVERSTEAM_GAME_KEY,
+    { baseRules: true },
     "build_track_before",
   );
 

--- a/src/e2e/util/game_data.ts
+++ b/src/e2e/util/game_data.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "fs/promises";
 import { resolve } from "path";
 import { GameStatus } from "../../api/game";
+import { GameKey } from "../../api/game_key";
 import { UserRole } from "../../api/user";
 import { VariantConfig } from "../../api/variant_config";
 import { SerializedGameData } from "../../engine/framework/state";
@@ -16,6 +17,7 @@ interface GameEnvironment {
 }
 
 export function setUpGameEnvironment(
+  gameKey: GameKey,
   variantConfig: VariantConfig,
   gameDataFile: string,
 ): GameEnvironment {
@@ -41,6 +43,7 @@ export function setUpGameEnvironment(
     }
 
     gameEnvironment.game = await initializeGame(
+      gameKey,
       variantConfig,
       gameData,
       gameEnvironment.activePlayer,
@@ -104,6 +107,7 @@ export async function compareGameData(game: GameDao, gameDataFile: string) {
 }
 
 async function initializeGame(
+  gameKey: GameKey,
   variantConfig: VariantConfig,
   gameData: SerializedGameData,
   currentPlayer: UserDao,
@@ -111,7 +115,7 @@ async function initializeGame(
 ): Promise<GameDao> {
   return GameDao.create({
     version: 1,
-    gameKey: variantConfig.gameKey,
+    gameKey,
     gameData: JSON.stringify(gameData),
     name: "Test game",
     status: GameStatus.enum.ACTIVE,

--- a/src/engine/game/map_settings.ts
+++ b/src/engine/game/map_settings.ts
@@ -1,3 +1,4 @@
+import { ZodTypeAny } from "zod";
 import { GameKey } from "../../api/game_key";
 import { Coordinates } from "../../utils/coordinates";
 import { assertNever } from "../../utils/validate";
@@ -71,6 +72,8 @@ export interface MapSettings {
   readonly rotation?: Rotation;
   // Development maps get an allowlist of user IDs who are allowed to create games for that map
   readonly developmentAllowlist?: number[];
+
+  readonly variantConfig?: ZodTypeAny;
 
   getOverrides(): Array<SimpleConstructor<unknown>>;
   getModules?(): Array<Module>;

--- a/src/maps/cyprus/key.ts
+++ b/src/maps/cyprus/key.ts
@@ -1,3 +1,0 @@
-import type { GameKey } from "../../api/game_key";
-
-export const CYPRUS_GAME_KEY = "cyprus" satisfies GameKey;

--- a/src/maps/cyprus/rules.tsx
+++ b/src/maps/cyprus/rules.tsx
@@ -1,4 +1,4 @@
-import { CyprusVariantConfig } from "../../api/variant_config";
+import { CyprusVariantConfig } from "./variant_config";
 import { RulesProps } from "../view_settings";
 
 export function CyprusRules({ variant }: RulesProps) {

--- a/src/maps/cyprus/settings.ts
+++ b/src/maps/cyprus/settings.ts
@@ -1,4 +1,4 @@
-import { CYPRUS_GAME_KEY } from "./key";
+import { GameKey } from "../../api/game_key";
 import {
   KAOSKODY,
   MapSettings,
@@ -10,6 +10,9 @@ import { CyprusAllowedActions } from "./limitted_selection";
 import { CyprusMoveAction } from "./move_goods";
 import { CyprusCostCalculator, ShortBuild } from "./short_build";
 import { CyprusStarter } from "./starter";
+import { CyprusVariantConfig } from "./variant_config";
+
+export const CYPRUS_GAME_KEY: GameKey = "cyprus";
 
 export class CyprusMapSettings implements MapSettings {
   static readonly key = CYPRUS_GAME_KEY;
@@ -31,6 +34,7 @@ export class CyprusMapSettings implements MapSettings {
   };
   readonly startingGrid = map;
   readonly stage = ReleaseStage.BETA;
+  readonly variantConfig = CyprusVariantConfig;
 
   getOverrides() {
     return [

--- a/src/maps/cyprus/short_build.ts
+++ b/src/maps/cyprus/short_build.ts
@@ -1,4 +1,4 @@
-import { CyprusVariantConfig } from "../../api/variant_config";
+import { CyprusVariantConfig } from "./variant_config";
 import { BuildCostCalculator } from "../../engine/build/cost";
 import { BuilderHelper } from "../../engine/build/helper";
 import { inject } from "../../engine/framework/execution_context";

--- a/src/maps/cyprus/variant_config.ts
+++ b/src/maps/cyprus/variant_config.ts
@@ -1,0 +1,6 @@
+import z from "zod";
+
+export const CyprusVariantConfig = z.object({
+  variant2020: z.boolean().optional(),
+});
+export type CyprusVariantConfig = z.infer<typeof CyprusVariantConfig>;

--- a/src/maps/cyprus/variant_editor.tsx
+++ b/src/maps/cyprus/variant_editor.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { CheckboxProps, FormCheckbox } from "semantic-ui-react";
-import { CyprusVariantConfig } from "../../api/variant_config";
+import { CyprusVariantConfig } from "./variant_config";
 import { VariantConfigProps } from "../view_settings";
 
 export function CyprusVariantEditor({

--- a/src/maps/cyprus/view_settings.ts
+++ b/src/maps/cyprus/view_settings.ts
@@ -1,7 +1,7 @@
-import { CyprusVariantConfig, VariantConfig } from "../../api/variant_config";
+import { VariantConfig } from "../../api/variant_config";
+import { CyprusVariantConfig } from "./variant_config";
 import { MapViewSettings } from "../view_settings";
 import { CyprusRules } from "./rules";
-import { CYPRUS_GAME_KEY } from "./key";
 import { CyprusMapSettings } from "./settings";
 import { CyprusVariantEditor } from "./variant_editor";
 
@@ -12,7 +12,7 @@ export class CyprusViewSettings
   getMapRules = CyprusRules;
 
   getInitialVariantConfig(): VariantConfig {
-    return { gameKey: CYPRUS_GAME_KEY, variant2020: true };
+    return { variant2020: true };
   }
   getVariantConfigEditor = CyprusVariantEditor;
 

--- a/src/maps/ireland/actions.ts
+++ b/src/maps/ireland/actions.ts
@@ -1,7 +1,7 @@
 import { Action, ActionNamingProvider } from "../../engine/state/action";
 import { inject } from "../../engine/framework/execution_context";
 import { GameMemory } from "../../engine/game/game_memory";
-import { IrelandVariantConfig } from "../../api/variant_config";
+import { IrelandVariantConfig } from "./variant_config";
 
 export class IrelandActionNamingProvider extends ActionNamingProvider {
   private readonly gameMemory = inject(GameMemory);

--- a/src/maps/ireland/key.ts
+++ b/src/maps/ireland/key.ts
@@ -1,3 +1,0 @@
-import type { GameKey } from "../../api/game_key";
-
-export const IRELAND_GAME_KEY = "ireland" satisfies GameKey;

--- a/src/maps/ireland/locomotive_action.ts
+++ b/src/maps/ireland/locomotive_action.ts
@@ -1,4 +1,4 @@
-import { IrelandVariantConfig } from "../../api/variant_config";
+import { IrelandVariantConfig } from "./variant_config";
 import { inject, injectState } from "../../engine/framework/execution_context";
 import { GameMemory } from "../../engine/game/game_memory";
 import { PHASE } from "../../engine/game/phase";

--- a/src/maps/ireland/rules.tsx
+++ b/src/maps/ireland/rules.tsx
@@ -1,4 +1,4 @@
-import { IrelandVariantConfig } from "../../api/variant_config";
+import { IrelandVariantConfig } from "./variant_config";
 import { RulesProps } from "../view_settings";
 
 export function IrelandRules({ variant: untyped }: RulesProps) {

--- a/src/maps/ireland/settings.ts
+++ b/src/maps/ireland/settings.ts
@@ -1,4 +1,3 @@
-import { IRELAND_GAME_KEY } from "./key";
 import {
   KAOSKODY,
   MapSettings,
@@ -14,9 +13,10 @@ import { IrelandLocoAction, IrelandMoveHelper } from "./locomotive_action";
 import { IrelandAllowedActions, IrelandSelectAction } from "./select_action";
 import { IrelandRoundEngine } from "./shortened_round";
 import { IrelandStarter } from "./starter";
+import { IrelandVariantConfig } from "./variant_config";
 
 export class IrelandMapSettings implements MapSettings {
-  static readonly key = IRELAND_GAME_KEY;
+  static readonly key = "ireland";
   readonly key = IrelandMapSettings.key;
   readonly name = "Ireland";
   readonly designer = "Martin Wallace";
@@ -36,6 +36,7 @@ export class IrelandMapSettings implements MapSettings {
   readonly startingGrid = map;
   readonly stage = ReleaseStage.BETA;
   readonly rotation = Rotation.CLOCKWISE;
+  readonly variantConfig = IrelandVariantConfig;
 
   getOverrides() {
     return [

--- a/src/maps/ireland/variant_config.ts
+++ b/src/maps/ireland/variant_config.ts
@@ -1,0 +1,6 @@
+import z from "zod";
+
+export const IrelandVariantConfig = z.object({
+  locoVariant: z.boolean(),
+});
+export type IrelandVariantConfig = z.infer<typeof IrelandVariantConfig>;

--- a/src/maps/ireland/variant_editor.tsx
+++ b/src/maps/ireland/variant_editor.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useCallback } from "react";
-import { IrelandVariantConfig } from "../../api/variant_config";
+import { IrelandVariantConfig } from "./variant_config";
 import { VariantConfigProps } from "../view_settings";
 import { CheckboxProps, FormCheckbox } from "semantic-ui-react";
 

--- a/src/maps/ireland/view_settings.ts
+++ b/src/maps/ireland/view_settings.ts
@@ -1,11 +1,11 @@
-import { IrelandVariantConfig, VariantConfig } from "../../api/variant_config";
+import { VariantConfig } from "../../api/variant_config";
+import { IrelandVariantConfig } from "./variant_config";
 import { ClickTarget, OnClickRegister } from "../../client/grid/click_target";
 import { useAction } from "../../client/services/action";
 import { MapViewSettings } from "../view_settings";
 import { DeurbanizeAction } from "./deurbanization";
 import { IrelandRivers } from "./rivers";
 import { IrelandRules } from "./rules";
-import { IRELAND_GAME_KEY } from "./key";
 import { IrelandMapSettings } from "./settings";
 import { IrelandVariantEditor } from "./variant_editor";
 
@@ -14,7 +14,7 @@ export class IrelandViewSettings
   implements MapViewSettings
 {
   getInitialVariantConfig(): VariantConfig {
-    return { gameKey: IRELAND_GAME_KEY, locoVariant: false };
+    return { locoVariant: false };
   }
   getVariantConfigEditor = IrelandVariantEditor;
 

--- a/src/maps/puerto_rico/key.ts
+++ b/src/maps/puerto_rico/key.ts
@@ -1,3 +1,0 @@
-import type { GameKey } from "../../api/game_key";
-
-export const PUERTO_RICO_GAME_KEY = "puerto-rico" satisfies GameKey;

--- a/src/maps/puerto_rico/settings.ts
+++ b/src/maps/puerto_rico/settings.ts
@@ -1,4 +1,3 @@
-import { PUERTO_RICO_GAME_KEY } from "./key";
 import {
   EMIL,
   MapSettings,
@@ -14,9 +13,10 @@ import { PuertoRicoPhaseEngine } from "./phases";
 import { PuertoRicoMoveAction } from "./move";
 import { PuertoRicoSelectActionPhase, PuertoRicoSkipAction } from "./actions";
 import { PuertoRicoPlayerHelper } from "./player";
+import { PuertoRicoVariantConfig } from "./variant_config";
 
 export class PuertoRicoMapSettings implements MapSettings {
-  readonly key = PUERTO_RICO_GAME_KEY;
+  readonly key = "puerto-rico";
   readonly name = "Puerto Rico";
   readonly designer = "Ted Alspach";
   readonly implementerId = EMIL;
@@ -34,6 +34,7 @@ export class PuertoRicoMapSettings implements MapSettings {
   };
   readonly startingGrid = map;
   readonly stage = ReleaseStage.DEVELOPMENT;
+  readonly variantConfig = PuertoRicoVariantConfig;
 
   getOverrides() {
     return [

--- a/src/maps/puerto_rico/starter.ts
+++ b/src/maps/puerto_rico/starter.ts
@@ -1,6 +1,6 @@
 import { inject } from "../../engine/framework/execution_context";
 import { GameMemory } from "../../engine/game/game_memory";
-import { PuertoRicoVariantConfig } from "../../api/variant_config";
+import { PuertoRicoVariantConfig } from "./variant_config";
 import { GameStarter, draw } from "../../engine/game/starter";
 import { Good } from "../../engine/state/good";
 import { duplicate } from "../../utils/functions";

--- a/src/maps/puerto_rico/variant_config.ts
+++ b/src/maps/puerto_rico/variant_config.ts
@@ -1,0 +1,7 @@
+import z from "zod";
+import { DIFFICULTY_LEVELS } from "./difficulty_levels";
+
+export const PuertoRicoVariantConfig = z.object({
+  difficulty: z.enum([...DIFFICULTY_LEVELS]),
+});
+export type PuertoRicoVariantConfig = z.infer<typeof PuertoRicoVariantConfig>;

--- a/src/maps/puerto_rico/variant_editor.tsx
+++ b/src/maps/puerto_rico/variant_editor.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { DropdownProps, FormDropdown } from "semantic-ui-react";
-import { PuertoRicoVariantConfig } from "../../api/variant_config";
+import { PuertoRicoVariantConfig } from "./variant_config";
 import { VariantConfigProps } from "../view_settings";
 import { DIFFICULTY_OPTIONS, type DifficultyLevel } from "./difficulty_levels";
 

--- a/src/maps/puerto_rico/view_settings.ts
+++ b/src/maps/puerto_rico/view_settings.ts
@@ -1,10 +1,7 @@
-import {
-  PuertoRicoVariantConfig,
-  VariantConfig,
-} from "../../api/variant_config";
+import { VariantConfig } from "../../api/variant_config";
+import { PuertoRicoVariantConfig } from "./variant_config";
 import { MapViewSettings } from "../view_settings";
 import { PuertoRicoRules } from "./rules";
-import { PUERTO_RICO_GAME_KEY } from "./key";
 import { PuertoRicoMapSettings } from "./settings";
 import { PuertoRicoVariantEditor } from "./variant_editor";
 
@@ -15,7 +12,7 @@ export class PuertoRicoViewSettings
   getMapRules = PuertoRicoRules;
 
   getInitialVariantConfig(): VariantConfig {
-    return { gameKey: PUERTO_RICO_GAME_KEY, difficulty: "versado" };
+    return { difficulty: "versado" };
   }
 
   getVariantConfigEditor = PuertoRicoVariantEditor;

--- a/src/maps/reversteam/accepts.ts
+++ b/src/maps/reversteam/accepts.ts
@@ -1,4 +1,4 @@
-import { ReversteamVariantConfig } from "../../api/variant_config";
+import { ReversteamVariantConfig } from "./variant_config";
 import { inject } from "../../engine/framework/execution_context";
 import { GameMemory } from "../../engine/game/game_memory";
 import { City } from "../../engine/map/city";

--- a/src/maps/reversteam/key.ts
+++ b/src/maps/reversteam/key.ts
@@ -1,3 +1,0 @@
-import type { GameKey } from "../../api/game_key";
-
-export const REVERSTEAM_GAME_KEY = "reversteam" satisfies GameKey;

--- a/src/maps/reversteam/rules.tsx
+++ b/src/maps/reversteam/rules.tsx
@@ -1,4 +1,4 @@
-import { ReversteamVariantConfig } from "../../api/variant_config";
+import { ReversteamVariantConfig } from "./variant_config";
 import { RulesProps } from "../view_settings";
 
 export function ReversteamRules({ variant }: RulesProps) {

--- a/src/maps/reversteam/settings.ts
+++ b/src/maps/reversteam/settings.ts
@@ -1,4 +1,4 @@
-import { REVERSTEAM_GAME_KEY } from "./key";
+import { GameKey } from "../../api/game_key";
 import {
   KAOSKODY,
   MapSettings,
@@ -7,6 +7,9 @@ import {
 } from "../../engine/game/map_settings";
 import { ReversteamMoveHelper } from "./accepts";
 import { map } from "./grid";
+import { ReversteamVariantConfig } from "./variant_config";
+
+export const REVERSTEAM_GAME_KEY: GameKey = "reversteam";
 
 export class ReversteamMapSettings implements MapSettings {
   readonly key = REVERSTEAM_GAME_KEY;
@@ -28,6 +31,7 @@ export class ReversteamMapSettings implements MapSettings {
   };
   readonly startingGrid = map;
   readonly stage = ReleaseStage.BETA;
+  readonly variantConfig = ReversteamVariantConfig;
 
   getOverrides() {
     return [ReversteamMoveHelper];

--- a/src/maps/reversteam/variant_config.ts
+++ b/src/maps/reversteam/variant_config.ts
@@ -1,0 +1,6 @@
+import z from "zod";
+
+export const ReversteamVariantConfig = z.object({
+  baseRules: z.boolean(),
+});
+export type ReversteamVariantConfig = z.infer<typeof ReversteamVariantConfig>;

--- a/src/maps/reversteam/variant_editor.tsx
+++ b/src/maps/reversteam/variant_editor.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useCallback } from "react";
-import { ReversteamVariantConfig } from "../../api/variant_config";
+import { ReversteamVariantConfig } from "./variant_config";
 import { VariantConfigProps } from "../view_settings";
 import { CheckboxProps, FormCheckbox } from "semantic-ui-react";
 

--- a/src/maps/reversteam/view_settings.ts
+++ b/src/maps/reversteam/view_settings.ts
@@ -1,11 +1,8 @@
-import {
-  ReversteamVariantConfig,
-  VariantConfig,
-} from "../../api/variant_config";
+import { VariantConfig } from "../../api/variant_config";
+import { ReversteamVariantConfig } from "./variant_config";
 import { MapViewSettings } from "../view_settings";
 import { ReversteamRivers } from "./rivers";
 import { ReversteamRules } from "./rules";
-import { REVERSTEAM_GAME_KEY } from "./key";
 import { ReversteamMapSettings } from "./settings";
 import { ReversteamVariantEditor } from "./variant_editor";
 
@@ -16,7 +13,7 @@ export class ReversteamViewSettings
   getTexturesLayer = ReversteamRivers;
 
   getInitialVariantConfig(): VariantConfig {
-    return { gameKey: REVERSTEAM_GAME_KEY, baseRules: false };
+    return { baseRules: false };
   }
   getVariantConfigEditor = ReversteamVariantEditor;
 

--- a/src/testing/injection_helper.ts
+++ b/src/testing/injection_helper.ts
@@ -7,8 +7,10 @@ import { setInjectionContext } from "../engine/framework/execution_context";
 import { InjectionContext } from "../engine/framework/inject";
 import { Key } from "../engine/framework/key";
 import { InjectedState, StateStore } from "../engine/framework/state";
-import { REVERSTEAM_GAME_KEY } from "../maps/reversteam/key";
-import { ReversteamMapSettings } from "../maps/reversteam/settings";
+import {
+  REVERSTEAM_GAME_KEY,
+  ReversteamMapSettings,
+} from "../maps/reversteam/settings";
 import { GameMemory } from "../engine/game/game_memory";
 import { resettable } from "./resettable";
 
@@ -28,7 +30,7 @@ export class InjectionHelper {
       helper.spyOn(GameMemory, "getGame").and.returnValue({
         id: 1,
         gameKey: REVERSTEAM_GAME_KEY,
-        variant: { gameKey: REVERSTEAM_GAME_KEY, baseRules: true },
+        variant: { baseRules: true },
       });
     });
 


### PR DESCRIPTION
Reverts #277 and resolves it with a more holistic approach of moving variant configs into the map-specific folders which avoids circular imports. The refine method on CreateGameApi is updated to utilize the map-specific variant config to still do input validation, which should have the same net effect as far as input validation goes.