### PR TITLE
Replace shared SpaceStyle enum with per-map style strings.

### DIFF
--- a/src/client/game/available_cities.tsx
+++ b/src/client/game/available_cities.tsx
@@ -28,7 +28,8 @@ export function AvailableCities() {
 }
 
 function AvailableCity({ city }: { city: MutableAvailableCity }) {
-  const mapSettings = MapRegistry.singleton.get(useGameKey());
+  const gameKey = useGameKey();
+  const mapSettings = MapRegistry.singleton.get(gameKey);
   const grid = useMemo(() => {
     const newCity = new City(Coordinates.from({ q: 0, r: 0 }), {
       type: SpaceType.CITY,
@@ -43,7 +44,7 @@ function AvailableCity({ city }: { city: MutableAvailableCity }) {
 
   return (
     <div>
-      <HexGrid grid={grid} />
+      <HexGrid grid={grid} gameKey={gameKey} />
     </div>
   );
 }

--- a/src/client/game/tile_manifest.tsx
+++ b/src/client/game/tile_manifest.tsx
@@ -53,7 +53,8 @@ function TileInfo({
   tileType: TileType;
   info: TileManifestEntry;
 }) {
-  const mapSettings = MapRegistry.singleton.get(useGameKey());
+  const gameKey = useGameKey();
+  const mapSettings = MapRegistry.singleton.get(gameKey);
   const grid = useMemo(() => {
     const tile = new Land(Coordinates.from({ q: 0, r: 0 }), {
       type: SpaceType.PLAIN,
@@ -70,7 +71,7 @@ function TileInfo({
 
   return (
     <div className={styles.tileContainer}>
-      <HexGrid grid={grid} />
+      <HexGrid grid={grid} gameKey={gameKey} />
       <div>
         {info.remaining}{" "}
         {towns > 0 && isComplexTile(tileType) ? (

--- a/src/client/grid/building_dialog.tsx
+++ b/src/client/grid/building_dialog.tsx
@@ -327,6 +327,7 @@ export function ModifiedSpace({
   return (
     <HexGrid
       grid={grid}
+      gameKey={settings.key}
       rotation={settings.rotation}
       onClick={onClick}
       clickTargets={clickTargets}

--- a/src/client/grid/hex.module.css
+++ b/src/client/grid/hex.module.css
@@ -14,22 +14,6 @@
   fill: #4a6c32;
 }
 
-.location.light_plain {
-  fill: #afe18e;
-}
-
-:global(.dark-mode) .location.light_plain {
-  fill: #5f8a40;
-}
-
-.location.fjord {
-  fill: #88d4ad;
-}
-
-:global(.dark-mode) .location.fjord {
-  fill: #6fad8e;
-}
-
 .location.fire {
   fill: #d66f34;
 }
@@ -44,14 +28,6 @@
 
 :global(.dark-mode) .location.river {
   fill: #466133;
-}
-
-.location.light_river {
-  fill: #a5d486;
-}
-
-:global(.dark-mode) .location.light_river {
-  fill: #58803b;
 }
 
 .location.water {
@@ -136,8 +112,4 @@
   stroke: #ffffff;
   stroke-width: 9;
   fill: none;
-}
-
-.location.canyon {
-  fill: #2b2b2b;
 }

--- a/src/client/grid/hex.tsx
+++ b/src/client/grid/hex.tsx
@@ -7,10 +7,11 @@ import { isTownTile } from "../../engine/map/tile";
 import { Track, TrackInfo } from "../../engine/map/track";
 import { CityGroup } from "../../engine/state/city_group";
 import { Good } from "../../engine/state/good";
-import { SpaceStyle } from "../../engine/state/location_style";
 import { SpaceType } from "../../engine/state/location_type";
 import { Direction } from "../../engine/state/tile";
+import { GameKey } from "../../api/game_key";
 import { CyprusMapData } from "../../maps/cyprus/map_data";
+import { ViewRegistry } from "../../maps/view_registry";
 import { Coordinates } from "../../utils/coordinates";
 import {
   coordinatesToCenter,
@@ -20,9 +21,9 @@ import {
   Point,
   polygon,
 } from "../../utils/point";
-import { assertNever } from "../../utils/validate";
+import { assert, assertNever } from "../../utils/validate";
+import { MapViewSettings } from "../../maps/view_settings";
 import { Rotate } from "../components/rotation";
-import { useGameKey } from "../utils/injection_context";
 import { ClickTarget } from "./click_target";
 import { goodStyle } from "./good";
 import { GoodBlock } from "./good_block";
@@ -43,25 +44,15 @@ function cityColorStyles(space: City): string[] {
     .map((color) => goodStyle(color));
 }
 
-function landColorStyle(space: Land): string {
+function landColorStyle(space: Land, viewSettings: MapViewSettings): string {
   const style = space.getSpaceStyle();
   if (style !== undefined) {
-    switch (style) {
-      case SpaceStyle.LIGHT_PLAIN:
-        return styles.light_plain;
-      case SpaceStyle.LIGHT_RIVER:
-        return styles.light_river;
-      case SpaceStyle.FJORD:
-        return styles.fjord;
-      case SpaceStyle.CANYON:
-        return styles.canyon;
-      case SpaceStyle.MOUNTAIN:
-        return styles.mountain;
-      case SpaceStyle.WATER:
-        return styles.water;
-      default:
-        assertNever(style);
-    }
+    const resolvedStyle = viewSettings.getLandStyles?.()[style];
+    assert(
+      resolvedStyle !== undefined,
+      `unknown land style "${style}" for map ${viewSettings.key}`,
+    );
+    return resolvedStyle;
   }
 
   const type = space.getLandType();
@@ -107,6 +98,7 @@ interface TerrainHexProps {
   rotation?: Rotation;
   selectedGood?: { good: Good; coordinates: Coordinates };
   highlightedTrack?: Track[];
+  gameKey: GameKey;
 }
 
 // The size of the inner part of city hexes, relative to the full size of the hex
@@ -133,7 +125,13 @@ export function getTerrainHexes(props: TerrainHexProps): TerrainHexes {
   };
 }
 
-function LowerTerrainHex({ space, size, clickTargets }: TerrainHexProps) {
+function LowerTerrainHex({
+  space,
+  size,
+  clickTargets,
+  gameKey,
+}: TerrainHexProps) {
+  const viewSettings = ViewRegistry.singleton.get(gameKey);
   const coordinates = space.coordinates;
   const center = useMemo(
     () => coordinatesToCenter(coordinates, size),
@@ -164,7 +162,7 @@ function LowerTerrainHex({ space, size, clickTargets }: TerrainHexProps) {
     isClickableCity || isClickableTown || isClickableBuild || isClaimableTrack;
 
   if (space instanceof Land) {
-    const hexColor = landColorStyle(space);
+    const hexColor = landColorStyle(space, viewSettings);
 
     return (
       <>
@@ -191,8 +189,7 @@ function LowerTerrainHex({ space, size, clickTargets }: TerrainHexProps) {
   }
 }
 
-function BorderBoundaries({ space, size }: TerrainHexProps) {
-  const gameKey = useGameKey();
+function BorderBoundaries({ space, size, gameKey }: TerrainHexProps) {
   const center = useMemo(
     () => coordinatesToCenter(space.coordinates, size),
     [space.coordinates, size],

--- a/src/client/grid/hex_grid.tsx
+++ b/src/client/grid/hex_grid.tsx
@@ -50,7 +50,7 @@ interface HexGridProps {
   selectedGood?: { good: Good; coordinates: Coordinates };
   clickTargets?: Set<ClickTarget>;
   fullMapVersion?: boolean;
-  gameKey?: GameKey;
+  gameKey: GameKey;
   children?: ReactNode;
 }
 
@@ -166,6 +166,7 @@ export function HexGrid({
           highlightedTrack: highlightedTrackInSpace,
           rotation,
           selectedGood,
+          gameKey,
         }),
       [
         isHighlighted,
@@ -177,6 +178,7 @@ export function HexGrid({
         rotation,
         highlightedTrackSerialized,
         selectedGood,
+        gameKey,
       ],
     );
 

--- a/src/engine/map/location.ts
+++ b/src/engine/map/location.ts
@@ -2,7 +2,6 @@ import { Coordinates } from "../../utils/coordinates";
 import { deepEquals } from "../../utils/deep_equals";
 import { assert, assertNever } from "../../utils/validate";
 import { Good } from "../state/good";
-import { SpaceStyle } from "../state/location_style";
 import { isUnpassable, LandData, LandType } from "../state/space";
 import {
   allDirections,
@@ -78,7 +77,7 @@ export class Land {
     return isUnpassable(this.getLandType());
   }
 
-  getSpaceStyle(): SpaceStyle | undefined {
+  getSpaceStyle(): string | undefined {
     return this.data.style;
   }
 

--- a/src/engine/state/location_style.ts
+++ b/src/engine/state/location_style.ts
@@ -1,13 +1,6 @@
 import z from "zod";
 
-export enum SpaceStyle {
-  // Don't change these numbers! They are stored in the DB like this.
-  LIGHT_PLAIN = 1,
-  LIGHT_RIVER = 2,
-  FJORD = 3,
-  CANYON = 4,
-  MOUNTAIN = 5,
-  WATER = 6,
-}
-
-export const SpaceStyleZod = z.nativeEnum(SpaceStyle);
+// Land spaces may carry any string style key, declared and resolved by the
+// owning map's MapViewSettings.getLandStyles() — there is no shared enum, so
+// a map is free to add new styles without touching shared code.
+export const SpaceStyleZod = z.string();

--- a/src/maps/chicago-l/grid.ts
+++ b/src/maps/chicago-l/grid.ts
@@ -1,11 +1,13 @@
 import { BLUE, PURPLE, RED } from "../../engine/state/good";
 import { city, grid, PLAIN, RIVER, town, UNPASSABLE, WATER } from "../factory";
-import { SpaceStyle } from "../../engine/state/location_style";
 import { CityData, LandData } from "../../engine/state/space";
 import z from "zod";
 import { SpaceType } from "../../engine/state/location_type";
 
 export const THE_LOOP_SAME_CITY = 1;
+
+// Chicago-L-specific style key, styled via ChicagoLViewSettings.getLandStyles().
+export const PARK_STYLE = "mountain";
 
 export const ChicagoLMapData = z.object({
   parkName: z.string().optional(),
@@ -16,7 +18,7 @@ export type ChicagoLMapData = z.infer<typeof ChicagoLMapData>;
 const park = (name: string): LandData => {
   return {
     ...WATER,
-    style: SpaceStyle.MOUNTAIN,
+    style: PARK_STYLE,
     mapSpecific: {
       parkName: name,
     },

--- a/src/maps/chicago-l/view_settings.tsx
+++ b/src/maps/chicago-l/view_settings.tsx
@@ -1,5 +1,7 @@
 import { MapViewSettings } from "../view_settings";
+import * as hexStyles from "../../client/grid/hex.module.css";
 import { ChicagoLOverlayLayer, ChicagoLTextures } from "./rivers";
+import { PARK_STYLE } from "./grid";
 import { ChicagoLMapSettings } from "./settings";
 import { ChicagoLRules } from "./rules";
 import { ClickTarget, OnClickRegister } from "../../client/grid/click_target";
@@ -22,6 +24,10 @@ export class ChicagoLViewSettings
   getOverlayLayer = ChicagoLOverlayLayer;
 
   getMapRules = ChicagoLRules;
+
+  getLandStyles = () => ({
+    [PARK_STYLE]: hexStyles.mountain,
+  });
 
   useOnMapClick = useRepopulateOnClick;
 

--- a/src/maps/denmark/denmark.module.css
+++ b/src/maps/denmark/denmark.module.css
@@ -1,0 +1,7 @@
+.fjord {
+  fill: #88d4ad;
+}
+
+:global(.dark-mode) .fjord {
+  fill: #6fad8e;
+}

--- a/src/maps/denmark/grid.ts
+++ b/src/maps/denmark/grid.ts
@@ -12,17 +12,19 @@ import {
   white,
 } from "../factory";
 import { BLUE, PURPLE, RED, YELLOW } from "../../engine/state/good";
-import { SpaceStyle } from "../../engine/state/location_style";
 import { LandData } from "../../engine/state/space";
 import { Direction } from "../../engine/state/tile";
 
+// Denmark-specific style key, styled via DenmarkViewSettings.getLandStyles().
+export const FJORD_STYLE = "fjord";
+
 const FJORD = {
   ...MOUNTAIN,
-  style: SpaceStyle.FJORD,
+  style: FJORD_STYLE,
 };
 
 function fjordTown(townName: string): LandData {
-  return { ...MOUNTAIN, townName: townName, style: SpaceStyle.FJORD };
+  return { ...MOUNTAIN, townName: townName, style: FJORD_STYLE };
 }
 function hillTown(townName: string): LandData {
   return { ...HILL, townName: townName };

--- a/src/maps/denmark/view_settings.ts
+++ b/src/maps/denmark/view_settings.ts
@@ -4,6 +4,8 @@ import { MapViewSettings } from "../view_settings";
 import { DenmarkRivers } from "./rivers";
 import { Phase } from "../../engine/state/phase";
 import { InstantProductionMoveGoodsActionSummary } from "../../modules/instant_production/instant_production_view";
+import * as styles from "./denmark.module.css";
+import { FJORD_STYLE } from "./grid";
 
 export class DenmarkViewSettings
   extends DenmarkMapSettings
@@ -11,6 +13,10 @@ export class DenmarkViewSettings
 {
   getMapRules = DenmarkRules;
   getTexturesLayer = DenmarkRivers;
+
+  getLandStyles = () => ({
+    [FJORD_STYLE]: styles.fjord,
+  });
 
   getActionSummary(phase: Phase) {
     if (phase === Phase.MOVING) {

--- a/src/maps/four_corners/four_corners.module.css
+++ b/src/maps/four_corners/four_corners.module.css
@@ -1,0 +1,3 @@
+.canyon {
+  fill: #2b2b2b;
+}

--- a/src/maps/four_corners/grid.ts
+++ b/src/maps/four_corners/grid.ts
@@ -1,7 +1,6 @@
 import { SpaceData, LandData } from "../../engine/state/space";
 import { Good } from "../../engine/state/good";
 import { duplicate } from "../../utils/functions";
-import { SpaceStyle } from "../../engine/state/location_style";
 import { SpaceType } from "../../engine/state/location_type";
 
 import {
@@ -16,9 +15,13 @@ import {
   white,
 } from "../factory";
 
+// Four-Corners-specific style key, styled via
+// FourCornersViewSettings.getLandStyles().
+export const CANYON_STYLE = "canyon";
+
 const CANYON: LandData = {
   type: SpaceType.UNPASSABLE,
-  style: SpaceStyle.CANYON,
+  style: CANYON_STYLE,
 };
 
 export const map = grid<SpaceData>([

--- a/src/maps/four_corners/view_settings.ts
+++ b/src/maps/four_corners/view_settings.ts
@@ -2,6 +2,8 @@ import { MapViewSettings } from "../view_settings";
 import { FourCornersRules } from "./rules";
 import { FourCornersMapSettings } from "./settings";
 import { FourCornersRivers } from "./rivers";
+import * as styles from "./four_corners.module.css";
+import { CANYON_STYLE } from "./grid";
 
 import { capturedCubesColumn } from "./captured_cubes_column";
 
@@ -11,6 +13,11 @@ export class FourCornersViewSettings
 {
   getMapRules = FourCornersRules;
   getTexturesLayer = FourCornersRivers;
+
+  getLandStyles = () => ({
+    [CANYON_STYLE]: styles.canyon,
+  });
+
   getPlayerStatColumns() {
     return [capturedCubesColumn];
   }

--- a/src/maps/japan/grid.ts
+++ b/src/maps/japan/grid.ts
@@ -12,7 +12,6 @@ import {
 } from "../factory";
 import z from "zod";
 import { Direction, DirectionZod } from "../../engine/state/tile";
-import { SpaceStyle } from "../../engine/state/location_style";
 import { LandData } from "../../engine/state/space";
 
 export const JapanMapData = z.object({
@@ -21,9 +20,12 @@ export const JapanMapData = z.object({
 });
 export type JapanMapData = z.infer<typeof JapanMapData>;
 
+// Japan-specific style key, styled via JapanViewSettings.getLandStyles().
+export const WATER_CROSSING_STYLE = "water";
+
 const WATER_CROSSING = {
   ...PLAIN,
-  style: SpaceStyle.WATER,
+  style: WATER_CROSSING_STYLE,
   mapSpecific: {
     waterCrossing: true,
   },

--- a/src/maps/japan/view_settings.tsx
+++ b/src/maps/japan/view_settings.tsx
@@ -2,6 +2,8 @@ import { MapViewSettings } from "../view_settings";
 import { JapanRivers } from "./rivers";
 import { JapanMapSettings } from "./settings";
 import { JapanRules } from "./rules";
+import * as hexStyles from "../../client/grid/hex.module.css";
+import { WATER_CROSSING_STYLE } from "./grid";
 
 export class JapanViewSettings
   extends JapanMapSettings
@@ -9,4 +11,8 @@ export class JapanViewSettings
 {
   getMapRules = JapanRules;
   getTexturesLayer = JapanRivers;
+
+  getLandStyles = () => ({
+    [WATER_CROSSING_STYLE]: hexStyles.water,
+  });
 }

--- a/src/maps/london/grid.ts
+++ b/src/maps/london/grid.ts
@@ -9,15 +9,19 @@ import {
   white,
 } from "../factory";
 import { BLUE, PURPLE, RED, YELLOW } from "../../engine/state/good";
-import { SpaceStyle } from "../../engine/state/location_style";
+
+// London-specific land styles, styled via LondonViewSettings.getLandStyles()
+// and london.module.css rather than the shared SpaceStyle enum/hex.module.css.
+export const LIGHT_PLAIN = "light_plain";
+export const LIGHT_RIVER = "light_river";
 
 const CENTRAL_LONDON_PLAIN = {
   ...PLAIN,
-  style: SpaceStyle.LIGHT_PLAIN,
+  style: LIGHT_PLAIN,
 };
 const CENTRAL_LONDON_RIVER = {
   ...RIVER,
-  style: SpaceStyle.LIGHT_RIVER,
+  style: LIGHT_RIVER,
 };
 
 export const map = grid([
@@ -154,7 +158,7 @@ export const map = grid([
     CENTRAL_LONDON_PLAIN,
     city("Waterloo", [RED], black(2), 3),
     CENTRAL_LONDON_RIVER,
-    { ...PLAIN, townName: "Brixton", style: SpaceStyle.LIGHT_PLAIN },
+    { ...PLAIN, townName: "Brixton", style: LIGHT_PLAIN },
     PLAIN,
     town("Streatham"),
     PLAIN,
@@ -178,7 +182,7 @@ export const map = grid([
     PLAIN,
     RIVER,
     CENTRAL_LONDON_RIVER,
-    { ...PLAIN, townName: "Deptford", style: SpaceStyle.LIGHT_PLAIN },
+    { ...PLAIN, townName: "Deptford", style: LIGHT_PLAIN },
     PLAIN,
     town("Forest Hill"),
     PLAIN,

--- a/src/maps/london/london.module.css
+++ b/src/maps/london/london.module.css
@@ -1,0 +1,15 @@
+.light_plain {
+  fill: #afe18e;
+}
+
+:global(.dark-mode) .light_plain {
+  fill: #5f8a40;
+}
+
+.light_river {
+  fill: #a5d486;
+}
+
+:global(.dark-mode) .light_river {
+  fill: #58803b;
+}

--- a/src/maps/london/view_settings.ts
+++ b/src/maps/london/view_settings.ts
@@ -4,6 +4,8 @@ import { MapViewSettings } from "../view_settings";
 import { LondonRivers } from "./rivers";
 import { Phase } from "../../engine/state/phase";
 import { InstantProductionMoveGoodsActionSummary } from "../../modules/instant_production/instant_production_view";
+import { LIGHT_PLAIN, LIGHT_RIVER } from "./grid";
+import * as styles from "./london.module.css";
 
 export class LondonViewSettings
   extends LondonMapSettings
@@ -11,6 +13,11 @@ export class LondonViewSettings
 {
   getMapRules = LondonRules;
   getTexturesLayer = LondonRivers;
+
+  getLandStyles = () => ({
+    [LIGHT_PLAIN]: styles.light_plain,
+    [LIGHT_RIVER]: styles.light_river,
+  });
 
   getActionSummary(phase: Phase) {
     if (phase === Phase.MOVING) {

--- a/src/maps/view_settings.ts
+++ b/src/maps/view_settings.ts
@@ -46,4 +46,9 @@ export interface MapViewSettings extends MapSettings {
     cell: ({ player }: { player: PlayerData }) => ReactNode;
   }>;
   useOnMapClick?: OnClickFunction;
+
+  // Map-specific land space styles, keyed by the string stored in a land
+  // space's `style` field. Lets a map bring its own CSS module for styling
+  // unique to it, instead of adding shared enum values/CSS for a single map.
+  getLandStyles?(): Record<string, string>;
 }

--- a/src/migrations/20260710000000_land_style_strings.ts
+++ b/src/migrations/20260710000000_land_style_strings.ts
@@ -1,0 +1,101 @@
+import { QueryTypes } from "@sequelize/core";
+import type { Migration } from "../scripts/migrations";
+
+// SpaceStyle used to be a numeric enum stored directly in the grid. It is now
+// a plain string, with LIGHT_PLAIN/LIGHT_RIVER moved to be London-specific
+// keys instead of shared enum values.
+const NUMBER_TO_STRING: Record<number, string> = {
+  1: "light_plain",
+  2: "light_river",
+  3: "fjord",
+  4: "canyon",
+  5: "mountain",
+  6: "water",
+};
+
+const STRING_TO_NUMBER: Record<string, number> = Object.fromEntries(
+  Object.entries(NUMBER_TO_STRING).map(([num, str]) => [str, Number(num)]),
+);
+
+function convertGrid(
+  gameData: unknown,
+  styleMap: Record<string | number, string | number>,
+): boolean {
+  if (
+    gameData == null ||
+    typeof gameData !== "object" ||
+    !("gameData" in gameData)
+  ) {
+    return false;
+  }
+  const inner = (gameData as { gameData: unknown }).gameData;
+  if (inner == null || typeof inner !== "object" || !("grid" in inner)) {
+    return false;
+  }
+  const grid = (inner as { grid: unknown }).grid;
+  if (!Array.isArray(grid)) {
+    return false;
+  }
+  let dirty = false;
+  for (const entry of grid) {
+    if (!Array.isArray(entry) || entry.length !== 2) {
+      continue;
+    }
+    const spaceData = entry[1];
+    if (
+      spaceData &&
+      typeof spaceData === "object" &&
+      "style" in spaceData &&
+      spaceData.style in styleMap
+    ) {
+      spaceData.style = styleMap[spaceData.style];
+      dirty = true;
+    }
+  }
+  return dirty;
+}
+
+async function migrateColumn(
+  queryInterface: Parameters<Migration>[0]["context"],
+  table: string,
+  column: string,
+  styleMap: Record<string | number, string | number>,
+): Promise<void> {
+  const [rows] = await queryInterface.sequelize.query(
+    `SELECT "id","${column}" FROM "${table}" WHERE "${column}" IS NOT NULL`,
+  );
+  for (const rowObj of rows) {
+    const row = rowObj as { id: string; [key: string]: string };
+    const id = row["id"];
+    const gameData = JSON.parse(row[column]);
+    if (convertGrid(gameData, styleMap)) {
+      await queryInterface.sequelize.query(
+        `UPDATE "${table}" SET "${column}"=? WHERE "id"=?`,
+        {
+          replacements: [JSON.stringify(gameData), id],
+          type: QueryTypes.UPDATE,
+        },
+      );
+    }
+  }
+}
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await migrateColumn(queryInterface, "Games", "gameData", NUMBER_TO_STRING);
+  await migrateColumn(
+    queryInterface,
+    "GameHistories",
+    "previousGameData",
+    NUMBER_TO_STRING,
+  );
+};
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await migrateColumn(queryInterface, "Games", "gameData", STRING_TO_NUMBER);
+  await migrateColumn(
+    queryInterface,
+    "GameHistories",
+    "previousGameData",
+    STRING_TO_NUMBER,
+  );
+};

--- a/src/modules/instant_production/instant_production_view.tsx
+++ b/src/modules/instant_production/instant_production_view.tsx
@@ -162,10 +162,11 @@ export function InstantProductionMoveGoodsActionSummary() {
 }
 
 function CityInfo({ city }: { city: City }) {
-  const mapSettings = MapRegistry.singleton.get(useGameKey());
+  const gameKey = useGameKey();
+  const mapSettings = MapRegistry.singleton.get(gameKey);
   const grid = useMemo(() => {
     return Grid.fromSpaces(mapSettings, [city], []);
   }, [mapSettings]);
 
-  return <HexGrid grid={grid} />;
+  return <HexGrid grid={grid} gameKey={gameKey} />;
 }


### PR DESCRIPTION
Each map now declares its own land-style constants and CSS module instead of relying on a shared SpaceStyle enum and shared style strings map. Also thread gameKey explicitly through hex-rendering props instead of relying on injection-context lookups, fixing "unfound maps with key undefined" when previewing a map without a game in context.