### PR TITLE
Fix cost for straight-tight extended with straight track

### DIFF
--- a/src/maps/pittsburgh/build_cost.ts
+++ b/src/maps/pittsburgh/build_cost.ts
@@ -2,15 +2,20 @@ import { Map } from "immutable";
 import { BuildCostCalculator } from "../../engine/build/cost";
 import { BuilderHelper } from "../../engine/build/helper";
 import { Land } from "../../engine/map/location";
-import { isTownTile } from "../../engine/map/tile";
+import {
+  isTownTile,
+  isComplexTile,
+  isSimpleTile,
+} from "../../engine/map/tile";
 import {
   ComplexTileType,
   Direction,
   SimpleTileType,
+  TileData,
   TileType,
 } from "../../engine/state/tile";
 import { Coordinates } from "../../utils/coordinates";
-import { assert } from "../../utils/validate";
+import { assert, assertNever } from "../../utils/validate";
 
 export class PittsburghBuilderHelper extends BuilderHelper {
   protected minimumBuildCost(): number {
@@ -28,10 +33,12 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     newTileType: TileType,
     orientation: Direction,
   ): number {
-    if (isTownTile(newTileType)) {
-      return 0;
-    }
-    return super.costOf(coordinates, newTileType, orientation);
+    const location = this.grid().get(coordinates);
+    assert(location instanceof Land, 'cannot calculate cost of track in non-buildable location');
+    const previousTileData = location.getTileData();
+
+    const overrideCost = this.overrideCost(previousTileData, newTileType);
+    return overrideCost ?? super.costOf(coordinates, newTileType, orientation);
   }
 
   protected getRedirectCost(
@@ -42,8 +49,8 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     assert(!isTownTile(newTileType));
     // https://boardgamegeek.com/thread/250037/article/1900582#1900582
     if (
-      this.getTileCost(previousTileType) !== 10 &&
-      this.getTileCost(newTileType) === 10
+      !this.containsStraight(previousTileType) &&
+      this.containsStraight(newTileType)
     ) {
       return 10;
     }
@@ -59,15 +66,9 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
   }
 
   protected getComplexUpgradeCost(
-    oldTileType: SimpleTileType,
-    newTileType: ComplexTileType,
+    _: SimpleTileType,
+    __: ComplexTileType,
   ) {
-    if (
-      this.getTileCost(oldTileType) !== 10 &&
-      this.getTileCost(newTileType) === 10
-    ) {
-      return 10;
-    }
     return 4;
   }
 
@@ -88,6 +89,49 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
       case ComplexTileType.CURVE_TIGHT_1:
       case ComplexTileType.CURVE_TIGHT_2:
         return 4;
+    }
+  }
+
+  private overrideCost(
+    previousTileData: TileData | undefined,
+    newTileType: TileType
+  ) : number | undefined {
+    if (isTownTile(newTileType)) {
+      return 0;
+    }
+    if (previousTileData == null) {
+      return undefined;
+    }
+    if (
+      isComplexTile(newTileType) &&
+      isSimpleTile(previousTileData.tileType) &&
+      !this.containsStraight(previousTileData.tileType) &&
+      this.containsStraight(newTileType)
+    ) {
+      return 10;
+    }
+    return undefined;
+  }
+
+  private containsStraight(tileType: SimpleTileType  | ComplexTileType ): boolean {
+    switch (tileType) {
+        // CONTAINS STRAIGHT TRACK
+        case SimpleTileType.STRAIGHT:
+        case ComplexTileType.X:
+        case ComplexTileType.BOW_AND_ARROW:
+        case ComplexTileType.STRAIGHT_TIGHT:
+          return true;
+
+        // CONTAINS NO STRAIGHT TRACK
+        case SimpleTileType.CURVE:
+        case SimpleTileType.TIGHT:
+        case ComplexTileType.CROSSING_CURVES:
+        case ComplexTileType.COEXISTING_CURVES:
+        case ComplexTileType.CURVE_TIGHT_1:
+        case ComplexTileType.CURVE_TIGHT_2:
+          return false;
+        default:
+          assertNever(tileType);
     }
   }
 }


### PR DESCRIPTION
## Fix `STRAIGHT_TIGHT` costing on Pittsburgh

The Pittsburgh map had an issue where build costs for coexisting complex track were not being calculated correctly.

On this map, any track configuration that introduces a straight segment should cost `$10`. This applies to simple straight track, complex track that adds a straight segment, and redirects that result in a straight segment.

Most cases were already handled correctly. In particular, `BOW_AND_ARROW` worked as expected because Pittsburgh overrides `getComplexUpgradeCost()` to account for those scenarios.

However, `STRAIGHT_TIGHT` had issues. Unlike `BOW_AND_ARROW`, it is a non-crossing complex track, so `BuildCostCalculator` never invokes `getComplexUpgradeCost()`. As a result, upgrading to `STRAIGHT_TIGHT` from a non-straight tile incorrectly fell through to the default redirect cost (`$2`) instead of charging `$10`.

### Solution

I moved this logic into Pittsburgh's overridden `costOf()` implementation, where all upgrades can be evaluated regardless of whether the resulting track crosses.

With this change, the special-case handling in `getComplexUpgradeCost()` became unnecessary and was removed. `getComplexUpgradeCost()` now always returns the standard complex upgrade cost of `$4`, while `costOf()` is responsible for handling Pittsburgh's straight-track exception.

### Additional Cleanup

While implementing the fix, I made a few small refactors to improve readability and consistency:

* Added `containsStraight()` to centralize "contains a straight segment" checks
* Added `overrideCost()` to simplify logic in `costOf()` implementation
* Removed redundant logic from `getComplexUpgradeCost()`

The only behavioral change introduced by this PR is that upgrades to `STRAIGHT_TIGHT` now correctly cost `$10` when a straight segment is introduced, matching the existing Pittsburgh map rules.
