### PR TITLE
Bugfix/pittsburgh improved build cost logic

### DIFF
--- a/src/engine/build/cost.ts
+++ b/src/engine/build/cost.ts
@@ -110,7 +110,7 @@ export class BuildCostCalculator {
   }
 }
 
-function countRedirects(originalTileData: TileData, newTileType: TileType, newOrientation: Direction) {
+export function countRedirects(originalTileData: TileData, newTileType: TileType, newOrientation: Direction) {
   if (isTownTile(originalTileData.tileType) || isTownTile(newTileType)) {
     return 0;
   }

--- a/src/maps/pittsburgh/build_cost.ts
+++ b/src/maps/pittsburgh/build_cost.ts
@@ -1,5 +1,5 @@
 import { Map } from "immutable";
-import { BuildCostCalculator } from "../../engine/build/cost";
+import { BuildCostCalculator, countRedirects } from "../../engine/build/cost";
 import { BuilderHelper } from "../../engine/build/helper";
 import { Land } from "../../engine/map/location";
 import {
@@ -28,27 +28,6 @@ export class PittsburghBuilderHelper extends BuilderHelper {
     return super.startingManifest().delete(ComplexTileType.X);
   }
 }
-
-// 
-// NOTE: track-cost logic is split between the engine's native costOf() function
-// and our custom override to accomodate Pittsburgh's costing peculiarities.
-// 
-// Cases handled by super's costOf():
-//   - is first tile placed in a hex (town, simple, or complex)
-//   - is a town->town upgrade
-//   - is a simple->simple redirect
-//   - simple->complex and complex->complex upgrades where 
-//       straight-before-and-after track is involved
-// 
-// Cases handled by overridden costOf():
-//   - simple->complex and complex->complex upgrades (excluding 
-//       cases where straight-before-and-after track are involved)
-// 
-// KNOWN BUG: Simple->complex and complex->complex upgrades are not costed properly
-// in cases where straight-before-and-after track are involved. They fallback to
-// engine's native costOf() fuction, where cost is based on number of redirects.
-// Bug not addressed in this PR.
-// 
 export class PittsburghFunkyBuilding extends BuildCostCalculator {
   costOf(
     coordinates: Coordinates,
@@ -59,77 +38,107 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     assert(location instanceof Land, 'cannot calculate cost of track in non-buildable location');
     const previousTileData = location.getTileData();
 
-    const overriddenCost = this.overrideCost(previousTileData, newTileType);
-    return overriddenCost ?? super.costOf(coordinates, newTileType, orientation);
+    if (!this.isComplexUpgrade(previousTileData, newTileType)) {
+      return super.costOf(coordinates, newTileType, orientation);
+    }
+
+    assert(!isTownTile(previousTileData.tileType));
+    assert(!isTownTile(newTileType));
+    const previousTileContainsStraight = this.containsStraight(previousTileData.tileType);
+    const newTileContainsStraight = this.containsStraight(newTileType);
+    if (!(previousTileContainsStraight && newTileContainsStraight)) {
+      return this.costForUnambiguousUpgrade(previousTileContainsStraight, newTileContainsStraight);
+    }
+
+    const isPreviousTileSimple = isSimpleTile(previousTileData.tileType);
+    const redirects = countRedirects(previousTileData, newTileType, orientation);
+    return this.costForAmbiguousUpgrade(isPreviousTileSimple, redirects);
   }
 
-  private overrideCost(
+  private costForAmbiguousUpgrade(
+    isPreviousTileSimple: boolean,
+    redirects: number
+  ): number {
+    const tileComplexity = isPreviousTileSimple ? "simple" : "complex";
+    if (isPreviousTileSimple) {
+      switch(redirects) {
+        case 0: 
+          return 4;
+        case 1:
+          return 10;
+        default:
+          assert(false, {
+            invalidInput: `unsupported number of redirects ${redirects} for ${tileComplexity} track`,
+          });
+      }
+    }
+    switch(redirects) {
+      case 0:
+      case 1: 
+        return 4;
+      case 2:
+        return 10;
+      default:
+        assert(false, {
+          invalidInput: `unsupported number of redirects ${redirects} for ${tileComplexity} track`,
+        });
+    }
+  }
+
+  private costForUnambiguousUpgrade(
+    previousTileContainsStraight: boolean,
+    newTileContainsStraight: boolean
+  ): number {
+    const containsNoStraight = !previousTileContainsStraight && !newTileContainsStraight;
+    if (containsNoStraight) { 
+      return 4;
+    }
+    const removedStraight = previousTileContainsStraight && !newTileContainsStraight;
+    if (removedStraight) {
+      return 4;
+    }
+    const introducedStraight = !previousTileContainsStraight && newTileContainsStraight;
+    if (introducedStraight) {
+      return 10;
+    }
+    assert(false, {
+      invalidInput: "this function will not accept straight->straight upgrades (aka ambiguous upgrades)"
+    });
+  }
+
+  private isComplexUpgrade(
     previousTileData: TileData | undefined,
     newTileType: TileType
-  ) : number | undefined {
+  ): previousTileData is TileData {
     const isFirstTile = previousTileData == null;
     if (isFirstTile) {
-      // Defers first tile pricing to super
-      return undefined;
+      return false;
     }
-    if (
-      isTownTile(previousTileData.tileType) ||
-      isTownTile(newTileType)
-    ) {
-      // Defers town tile upgrade pricing to super
-      return undefined;
+    const isTownUpgrade = isTownTile(previousTileData.tileType) && isTownTile(newTileType)
+    if (isTownUpgrade) {
+      return false;
     }
-    if (
-      isSimpleTile(previousTileData.tileType) &&
-      isSimpleTile(newTileType)
-    ) {
-      // Defers simple tile redirect pricing to super
-      return undefined;
+    const isSimpleRedirect = isSimpleTile(previousTileData.tileType) && isSimpleTile(newTileType)
+    if (isSimpleRedirect) {
+      return false;
+    }
+    const isComplexToSimpleRedirect = isComplexTile(previousTileData.tileType) && isSimpleTile(newTileType)
+    if (isComplexToSimpleRedirect) {
+      return false;
     }
 
-    // Checking for simple->complex or complex->complex tile upgrades.
-    if (isComplexTile(newTileType)) {
-      return this.costForComplexUpgrade(
-        this.containsStraight(previousTileData.tileType),
-        this.containsStraight(newTileType)
-      );
-    }
-
-    // Defers to engine to handle impossible track upgrades
-    // (ie complex->simple upgrade)
-    return undefined;
+    return true;
   }
 
-  // Currently receives BOTH (simple->simple redirects) AND (simple->complex and
-  // complex->complex cases from overrideCost()).
-  // Once that's fixed to handle complex cases itself, this function should go back
-  // to simple->simple only.
-  // This exists to preserve existing erroneous costs.
   protected getRedirectCost(
     previousTileType: TileType,
     newTileType: TileType,
   ): number {
     assert(!isTownTile(previousTileType));
     assert(!isTownTile(newTileType));
-    // Can be removed once straight-before-and-after complex-upgrade cost bug is resolved.
-    if (
-      this.containsStraight(previousTileType) &&
-      this.containsStraight(newTileType)
-    ) {
-      return 4;
-    }
 
     // https://boardgamegeek.com/thread/250037/article/1900582#1900582
     return this.containsStraight(newTileType) ? 10 : 3;
-  }
-
-  // Can be removed once straight-before-and-after complex-upgrade cost bug is resolved.
-  // Necessary to preserve existing costs.
-  protected getComplexUpgradeCost(
-    _: SimpleTileType,
-    __: ComplexTileType
-  ) {
-    return 4;
   }
 
   protected getTerrainCost(_: Land): number {
@@ -166,25 +175,6 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
       case ComplexTileType.CURVE_TIGHT_2:
         return 4;
     }
-  }
-
-  private costForComplexUpgrade(
-    previousTileStraight: boolean,
-    newTileStraight: boolean
-  ): number | undefined {
-    if (!previousTileStraight && !newTileStraight) { 
-      return 4;
-    }
-    if (!previousTileStraight && newTileStraight) {
-      return 10;
-    }
-    if (previousTileStraight && !newTileStraight) {
-      return 4;
-    }
-
-    // previousTileStraight && newTileStraight
-    // Straight-before-and-after complex-upgrade cost bug can be resolved here
-    return undefined;
   }
 
   private containsStraight(tileType: SimpleTileType  | ComplexTileType ): boolean {

--- a/src/maps/pittsburgh/build_cost.ts
+++ b/src/maps/pittsburgh/build_cost.ts
@@ -29,24 +29,26 @@ export class PittsburghBuilderHelper extends BuilderHelper {
   }
 }
 
-/**
- * NOTE: track-costing logic for this map is split across two locations,
- * and both need to be checked when reasoning about or modifying costs:
- *
- *   1. costOf() (override)         — entry point; delegates to overrideCost()
- *      and falls back to super.costOf() when overrideCost() returns undefined.
- *   2. overrideCost() (this class) — custom pricing rules specific
- *      to this map (first-tile complex pricing, simple->complex transitions,
- *      complex->complex redirects). Returns undefined for any case it
- *      doesn't own, deferring to super.
- *
- * KNOWN ISSUE (as of 2026-07-18): overrideCost() currently has two
- * paths that both defer to super (the isSimpleToSimple guard,
- * and the fallthrough at the bottom of the function), and not yet
- * confirmed whether these represent the same underlying case or two
- * genuinely different ones. Needs a pass to verify before relying on this
- * structure further.
- */ 
+// 
+// NOTE: track-cost logic is split between the engine's native costOf() function
+// and our custom override to accomodate Pittsburgh's costing peculiarities.
+// 
+// Cases handled by super's costOf():
+//   - is first tile placed in a hex (town, simple, or complex)
+//   - is a town->town upgrade
+//   - is a simple->simple redirect
+//   - simple->complex and complex->complex upgrades where 
+//       straight-before-and-after track is involved
+// 
+// Cases handled by overridden costOf():
+//   - simple->complex and complex->complex upgrades (excluding 
+//       cases where straight-before-and-after track are involved)
+// 
+// KNOWN BUG: Simple->complex and complex->complex upgrades are not costed properly
+// in cases where straight-before-and-after track are involved. They fallback to
+// engine's native costOf() fuction, where cost is based on number of redirects.
+// Bug not addressed in this PR.
+// 
 export class PittsburghFunkyBuilding extends BuildCostCalculator {
   costOf(
     coordinates: Coordinates,
@@ -57,29 +59,35 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     assert(location instanceof Land, 'cannot calculate cost of track in non-buildable location');
     const previousTileData = location.getTileData();
 
-    const overrideCost = this.overrideCost(previousTileData, newTileType);
-    return overrideCost ?? super.costOf(coordinates, newTileType, orientation);
+    const overriddenCost = this.overrideCost(previousTileData, newTileType);
+    return overriddenCost ?? super.costOf(coordinates, newTileType, orientation);
   }
 
   private overrideCost(
     previousTileData: TileData | undefined,
     newTileType: TileType
   ) : number | undefined {
-    // fallback to superclass/overrides in these cases
     const isFirstTile = previousTileData == null;
     if (isFirstTile) {
+      // Defers first tile pricing to super
       return undefined;
     }
     if (
       isTownTile(previousTileData.tileType) ||
       isTownTile(newTileType)
     ) {
+      // Defers town tile upgrade pricing to super
       return undefined;
     }
-    if (this.isSimpleToSimple(previousTileData.tileType, newTileType)) {
+    if (
+      isSimpleTile(previousTileData.tileType) &&
+      isSimpleTile(newTileType)
+    ) {
+      // Defers simple tile redirect pricing to super
       return undefined;
     }
 
+    // Checking for simple->complex or complex->complex tile upgrades.
     if (isComplexTile(newTileType)) {
       return this.costForComplexUpgrade(
         this.containsStraight(previousTileData.tileType),
@@ -87,25 +95,33 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
       );
     }
 
+    // Defers to engine to handle impossible track upgrades
+    // (ie complex->simple upgrade)
     return undefined;
   }
 
+  // Currently receives BOTH (simple->simple redirects) AND (simple->complex and
+  // complex->complex cases from overrideCost()).
+  // Once that's fixed to handle complex cases itself, this function should go back
+  // to simple->simple only.
+  // This exists to preserve existing erroneous costs.
   protected getRedirectCost(
     previousTileType: TileType,
     newTileType: TileType,
   ): number {
     assert(!isTownTile(previousTileType));
     assert(!isTownTile(newTileType));
-    // https://boardgamegeek.com/thread/250037/article/1900582#1900582
+    // Can be removed once straight-before-and-after complex-upgrade cost bug is resolved.
     if (
-      !this.containsStraight(previousTileType) &&
+      this.containsStraight(previousTileType) &&
       this.containsStraight(newTileType)
     ) {
-      return 10;
+      return 4;
     }
-    if (!this.containsStraight(newTileType)) {
-      return 3;
-    }
+
+    // https://boardgamegeek.com/thread/250037/article/1900582#1900582
+    return this.containsStraight(newTileType) ? 10 : 3;
+  }
 
   // Can be removed once straight-before-and-after complex-upgrade cost bug is resolved.
   // Necessary to preserve existing costs.
@@ -132,13 +148,6 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     return 0;
   }
 
-  protected getComplexUpgradeCost(
-    _: SimpleTileType,
-    __: ComplexTileType,
-  ) {
-    return 4;
-  }
-
   protected getTileCost(tileType: SimpleTileType | ComplexTileType): number {
     switch (tileType) {
       case SimpleTileType.STRAIGHT:
@@ -163,17 +172,19 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     previousTileStraight: boolean,
     newTileStraight: boolean
   ): number | undefined {
-    if (!previousTileStraight && !newTileStraight) return 4;
-    if (!previousTileStraight && newTileStraight) return 10;
-    if (previousTileStraight && !newTileStraight) return 4;
+    if (!previousTileStraight && !newTileStraight) { 
+      return 4;
+    }
+    if (!previousTileStraight && newTileStraight) {
+      return 10;
+    }
+    if (previousTileStraight && !newTileStraight) {
+      return 4;
+    }
 
-    // straightBefore && straightAfter
+    // previousTileStraight && newTileStraight
+    // Straight-before-and-after complex-upgrade cost bug can be resolved here
     return undefined;
-  }
-
-  private isSimpleToSimple(previousTileType: TileType, newTileType: TileType): boolean {
-    return isSimpleTile(newTileType) &&
-      isSimpleTile(previousTileType);
   }
 
   private containsStraight(tileType: SimpleTileType  | ComplexTileType ): boolean {

--- a/src/maps/pittsburgh/build_cost.ts
+++ b/src/maps/pittsburgh/build_cost.ts
@@ -106,6 +106,13 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     if (!this.containsStraight(newTileType)) {
       return 3;
     }
+
+  // Can be removed once straight-before-and-after complex-upgrade cost bug is resolved.
+  // Necessary to preserve existing costs.
+  protected getComplexUpgradeCost(
+    _: SimpleTileType,
+    __: ComplexTileType
+  ) {
     return 4;
   }
 

--- a/src/maps/pittsburgh/build_cost.ts
+++ b/src/maps/pittsburgh/build_cost.ts
@@ -2,15 +2,22 @@ import { Map } from "immutable";
 import { BuildCostCalculator } from "../../engine/build/cost";
 import { BuilderHelper } from "../../engine/build/helper";
 import { Land } from "../../engine/map/location";
-import { isTownTile } from "../../engine/map/tile";
+import {
+  isTownTile,
+  isComplexTile,
+  isSimpleTile,
+} from "../../engine/map/tile";
 import {
   ComplexTileType,
   Direction,
   SimpleTileType,
+  TileData,
   TileType,
+  TownTileType
 } from "../../engine/state/tile";
+import { LandType } from "../../engine/state/space";
 import { Coordinates } from "../../utils/coordinates";
-import { assert } from "../../utils/validate";
+import { assert, assertNever } from "../../utils/validate";
 
 export class PittsburghBuilderHelper extends BuilderHelper {
   protected minimumBuildCost(): number {
@@ -22,16 +29,65 @@ export class PittsburghBuilderHelper extends BuilderHelper {
   }
 }
 
+/**
+ * NOTE: track-costing logic for this map is split across two locations,
+ * and both need to be checked when reasoning about or modifying costs:
+ *
+ *   1. costOf() (override)         — entry point; delegates to overrideCost()
+ *      and falls back to super.costOf() when overrideCost() returns undefined.
+ *   2. overrideCost() (this class) — custom pricing rules specific
+ *      to this map (first-tile complex pricing, simple->complex transitions,
+ *      complex->complex redirects). Returns undefined for any case it
+ *      doesn't own, deferring to super.
+ *
+ * KNOWN ISSUE (as of 2026-07-18): overrideCost() currently has two
+ * paths that both defer to super (the isSimpleToSimple guard,
+ * and the fallthrough at the bottom of the function), and not yet
+ * confirmed whether these represent the same underlying case or two
+ * genuinely different ones. Needs a pass to verify before relying on this
+ * structure further.
+ */ 
 export class PittsburghFunkyBuilding extends BuildCostCalculator {
   costOf(
     coordinates: Coordinates,
     newTileType: TileType,
     orientation: Direction,
   ): number {
-    if (isTownTile(newTileType)) {
-      return 0;
+    const location = this.grid().get(coordinates);
+    assert(location instanceof Land, 'cannot calculate cost of track in non-buildable location');
+    const previousTileData = location.getTileData();
+
+    const overrideCost = this.overrideCost(previousTileData, newTileType);
+    return overrideCost ?? super.costOf(coordinates, newTileType, orientation);
+  }
+
+  private overrideCost(
+    previousTileData: TileData | undefined,
+    newTileType: TileType
+  ) : number | undefined {
+    // fallback to superclass/overrides in these cases
+    const isFirstTile = previousTileData == null;
+    if (isFirstTile) {
+      return undefined;
     }
-    return super.costOf(coordinates, newTileType, orientation);
+    if (
+      isTownTile(previousTileData.tileType) ||
+      isTownTile(newTileType)
+    ) {
+      return undefined;
+    }
+    if (this.isSimpleToSimple(previousTileData.tileType, newTileType)) {
+      return undefined;
+    }
+
+    if (isComplexTile(newTileType)) {
+      return this.costForComplexUpgrade(
+        this.containsStraight(previousTileData.tileType),
+        this.containsStraight(newTileType)
+      );
+    }
+
+    return undefined;
   }
 
   protected getRedirectCost(
@@ -42,10 +98,13 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     assert(!isTownTile(newTileType));
     // https://boardgamegeek.com/thread/250037/article/1900582#1900582
     if (
-      this.getTileCost(previousTileType) !== 10 &&
-      this.getTileCost(newTileType) === 10
+      !this.containsStraight(previousTileType) &&
+      this.containsStraight(newTileType)
     ) {
       return 10;
+    }
+    if (!this.containsStraight(newTileType)) {
+      return 3;
     }
     return 4;
   }
@@ -58,16 +117,18 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     return 0;
   }
 
+  protected getTownTileCost(_: TownTileType): number {
+    return 0;
+  }
+
+  protected getCostOfLandTypeForTown(_: LandType): number {
+    return 0;
+  }
+
   protected getComplexUpgradeCost(
-    oldTileType: SimpleTileType,
-    newTileType: ComplexTileType,
+    _: SimpleTileType,
+    __: ComplexTileType,
   ) {
-    if (
-      this.getTileCost(oldTileType) !== 10 &&
-      this.getTileCost(newTileType) === 10
-    ) {
-      return 10;
-    }
     return 4;
   }
 
@@ -88,6 +149,45 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
       case ComplexTileType.CURVE_TIGHT_1:
       case ComplexTileType.CURVE_TIGHT_2:
         return 4;
+    }
+  }
+
+  private costForComplexUpgrade(
+    previousTileStraight: boolean,
+    newTileStraight: boolean
+  ): number | undefined {
+    if (!previousTileStraight && !newTileStraight) return 4;
+    if (!previousTileStraight && newTileStraight) return 10;
+    if (previousTileStraight && !newTileStraight) return 4;
+
+    // straightBefore && straightAfter
+    return undefined;
+  }
+
+  private isSimpleToSimple(previousTileType: TileType, newTileType: TileType): boolean {
+    return isSimpleTile(newTileType) &&
+      isSimpleTile(previousTileType);
+  }
+
+  private containsStraight(tileType: SimpleTileType  | ComplexTileType ): boolean {
+    switch (tileType) {
+        // CONTAINS STRAIGHT TRACK
+        case SimpleTileType.STRAIGHT:
+        case ComplexTileType.X:
+        case ComplexTileType.BOW_AND_ARROW:
+        case ComplexTileType.STRAIGHT_TIGHT:
+          return true;
+
+        // CONTAINS NO STRAIGHT TRACK
+        case SimpleTileType.CURVE:
+        case SimpleTileType.TIGHT:
+        case ComplexTileType.CROSSING_CURVES:
+        case ComplexTileType.COEXISTING_CURVES:
+        case ComplexTileType.CURVE_TIGHT_1:
+        case ComplexTileType.CURVE_TIGHT_2:
+          return false;
+        default:
+          assertNever(tileType);
     }
   }
 }

--- a/src/maps/pittsburgh/build_cost.ts
+++ b/src/maps/pittsburgh/build_cost.ts
@@ -138,7 +138,7 @@ export class PittsburghFunkyBuilding extends BuildCostCalculator {
     assert(!isTownTile(newTileType));
 
     // https://boardgamegeek.com/thread/250037/article/1900582#1900582
-    return this.containsStraight(newTileType) ? 10 : 3;
+    return this.containsStraight(newTileType) ? 10 : 4;
   }
 
   protected getTerrainCost(_: Land): number {

--- a/src/maps/pittsburgh/build_cost_test.ts
+++ b/src/maps/pittsburgh/build_cost_test.ts
@@ -1,0 +1,184 @@
+import 'jasmine';
+import { InjectionHelper } from '../../testing/injection_helper';
+import { Coordinates } from '../../utils/coordinates';
+import { GRID, INTER_CITY_CONNECTIONS } from '../../engine/game/state';
+import { isTownTile } from '../../engine/map/tile';
+import { SpaceType } from '../../engine/state/location_type';
+import { LandData, SpaceData } from '../../engine/state/space';
+import { BOTTOM_LEFT, ComplexTileType, Direction, SimpleTileType, TileType, TOP, TownTileType } from '../../engine/state/tile';
+import { PittsburghFunkyBuilding } from "../../maps/pittsburgh/build_cost";
+import { directionToRad, TOP_RIGHT } from '../../utils/point';
+
+const { PLAIN } = SpaceType;
+const {
+  LOLLYPOP,
+  THREE_WAY,
+  LEFT_LEANER,
+  RIGHT_LEANER,
+  TIGHT_THREE,
+  CHICKEN_FOOT,
+  K,
+} = TownTileType;
+
+const {
+  // CROSSING
+  BOW_AND_ARROW,
+  CROSSING_CURVES,
+
+  // COEXISTING
+  STRAIGHT_TIGHT,
+  COEXISTING_CURVES,
+  CURVE_TIGHT_1,
+  CURVE_TIGHT_2,
+} = ComplexTileType;
+
+
+describe(PittsburghFunkyBuilding.name, () => {
+  const injector = InjectionHelper.install();
+
+  interface CalculateCostProps {
+    from?: TileType;
+    to: TileType;
+    type?: LandData['type'];
+    fromOrientation?: Direction;
+    toOrientation?: Direction;
+  }
+
+  injector.initResettableState(GRID, new Map());
+  injector.initResettableState(INTER_CITY_CONNECTIONS, []);
+
+  function calculateCost({ from, to, type, fromOrientation, toOrientation }: CalculateCostProps) {
+    const coordinates = Coordinates.from({ q: 0, r: 0 });
+    const grid = new Map<Coordinates, SpaceData>([
+      [coordinates, {
+        type: type ?? PLAIN,
+        townName: isTownTile(to) ? 'Foo Town' : undefined,
+        tile: from && {
+          tileType: from,
+          orientation: fromOrientation ?? Direction.TOP,
+          owners: [undefined],
+        },
+      }],
+    ]);
+    injector.state().set(GRID, grid);
+
+    const calculator = new PittsburghFunkyBuilding();
+    return calculator.costOf(coordinates, to, toOrientation ?? Direction.TOP);
+  }
+
+  describe('is first tile', () => {
+    it('and is simple straight track (costs $10)', () => {
+        expect(calculateCost({ to: SimpleTileType.STRAIGHT })).toBe(10);
+    });
+
+    it('and is simple non-straight track (costs $3)', () => {
+        expect(calculateCost({ to: SimpleTileType.CURVE })).toBe(3);
+        expect(calculateCost({ to: SimpleTileType.TIGHT })).toBe(3);
+    });
+
+    it('and is straight complex track (costs $10)', () => {
+        expect(calculateCost({ to: BOW_AND_ARROW, type: PLAIN })).toBe(10);
+        expect(calculateCost({ to: STRAIGHT_TIGHT, type: PLAIN })).toBe(10);
+    });
+
+    it('and is non-straight complex track (costs $4)', () => {
+        expect(calculateCost({ to: CROSSING_CURVES, type: PLAIN })).toBe(4);    
+        expect(calculateCost({ to: COEXISTING_CURVES, type: PLAIN })).toBe(4);
+        expect(calculateCost({ to: CURVE_TIGHT_1, type: PLAIN })).toBe(4);
+        expect(calculateCost({ to: CURVE_TIGHT_2, type: PLAIN })).toBe(4);
+    });
+
+    it('and is town (always costs $0)', () => {
+        expect(calculateCost({ to: LOLLYPOP })).toBe(0);
+        expect(calculateCost({ to: TownTileType.STRAIGHT })).toBe(0);
+        expect(calculateCost({ to: TownTileType.CURVE })).toBe(0);
+        expect(calculateCost({ to: TownTileType.TIGHT })).toBe(0);
+        expect(calculateCost({ to: THREE_WAY })).toBe(0);
+        expect(calculateCost({ to: LEFT_LEANER })).toBe(0);
+        expect(calculateCost({ to: RIGHT_LEANER })).toBe(0);
+        expect(calculateCost({ to: TIGHT_THREE })).toBe(0);
+        expect(calculateCost({ to: CHICKEN_FOOT })).toBe(0);
+        expect(calculateCost({ to: K })).toBe(0);
+    });
+  });
+
+  it('upgrading a town always costs $0', () => {
+    expect(calculateCost({ from: LOLLYPOP, to: TownTileType.STRAIGHT })).toBe(0);
+    expect(calculateCost({ from: TownTileType.STRAIGHT, to: CHICKEN_FOOT })).toBe(0);
+    expect(calculateCost({ from: TownTileType.LEFT_LEANER, to: TownTileType.K })).toBe(0);
+  });
+
+  describe('rerouting a simple tile', () => {
+    it('to straight (costs $10)', () => {
+        expect(calculateCost({ from: SimpleTileType.CURVE, to: SimpleTileType.STRAIGHT })).toBe(10);
+        expect(calculateCost({ from: SimpleTileType.TIGHT, to: SimpleTileType.STRAIGHT })).toBe(10);
+    });
+
+    it('to non-straight (costs $3)', () => {
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: SimpleTileType.CURVE })).toBe(3);
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: SimpleTileType.TIGHT })).toBe(3);
+        expect(calculateCost({ from: SimpleTileType.TIGHT, to: SimpleTileType.CURVE })).toBe(3);
+        expect(calculateCost({ from: SimpleTileType.CURVE, to: SimpleTileType.TIGHT })).toBe(3);
+    });
+  });
+
+  describe('simple->complex upgrade', () => {
+    it('with !straight->!straight (costs $4)', () => {
+        expect(calculateCost({ from: SimpleTileType.TIGHT, to: CURVE_TIGHT_1, toOrientation: Direction.TOP_RIGHT })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.TIGHT, to: CURVE_TIGHT_2 })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.CURVE, to: CROSSING_CURVES })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.CURVE, to: COEXISTING_CURVES })).toBe(4);
+    });
+
+    it('with !straight->straight (costs $10)', () => {
+        expect(calculateCost({ from: SimpleTileType.TIGHT, to: STRAIGHT_TIGHT, toOrientation: Direction.TOP_RIGHT })).toBe(10);
+        expect(calculateCost({ from: SimpleTileType.TIGHT, to: BOW_AND_ARROW })).toBe(10);
+        expect(calculateCost({ from: SimpleTileType.CURVE, to: BOW_AND_ARROW, toOrientation: Direction.BOTTOM_RIGHT })).toBe(10);
+        expect(calculateCost({ from: SimpleTileType.CURVE, to: STRAIGHT_TIGHT })).toBe(10);
+    });
+
+    it('with straight->!straight (costs $4)', () => {
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: COEXISTING_CURVES })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: CURVE_TIGHT_1 })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: CURVE_TIGHT_2 })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: CROSSING_CURVES })).toBe(4);
+    });
+
+    it('with straight->straight calculation', () => {
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: STRAIGHT_TIGHT })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: STRAIGHT_TIGHT, toOrientation: Direction.TOP_LEFT })).toBe(10);
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: BOW_AND_ARROW })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: BOW_AND_ARROW, toOrientation: Direction.TOP_LEFT })).toBe(10);
+    });
+  });
+
+  describe('complex->complex upgrade', () => {
+    it('with !straight->!straight (costs $4)', () => {
+        expect(calculateCost({ from: CURVE_TIGHT_2, to: COEXISTING_CURVES })).toBe(4);
+        expect(calculateCost({ from: CURVE_TIGHT_2, to: CROSSING_CURVES })).toBe(4);
+        expect(calculateCost({ from: CROSSING_CURVES, to: CURVE_TIGHT_1, toOrientation: Direction.BOTTOM })).toBe(4);
+        expect(calculateCost({ from: COEXISTING_CURVES, to: CROSSING_CURVES, toOrientation: Direction.TOP_RIGHT })).toBe(4);
+    });
+
+    it('with !straight->straight (costs $10)', () => {
+        expect(calculateCost({ from: CURVE_TIGHT_1, to: STRAIGHT_TIGHT })).toBe(10);
+        expect(calculateCost({ from: CURVE_TIGHT_1, to: STRAIGHT_TIGHT, toOrientation: Direction.BOTTOM_LEFT })).toBe(10);
+        expect(calculateCost({ from: CROSSING_CURVES, to: BOW_AND_ARROW, toOrientation: Direction.TOP_RIGHT })).toBe(10);
+        expect(calculateCost({ from: CURVE_TIGHT_2, to: BOW_AND_ARROW, toOrientation: Direction.BOTTOM_LEFT })).toBe(10);
+    });
+
+    it('with straight->!straight (costs $4)', () => {
+        expect(calculateCost({ from: STRAIGHT_TIGHT, to: CURVE_TIGHT_1 })).toBe(4);
+        expect(calculateCost({ from: STRAIGHT_TIGHT, to: CROSSING_CURVES })).toBe(4);
+        expect(calculateCost({ from: BOW_AND_ARROW, to: CROSSING_CURVES, toOrientation: Direction.TOP_LEFT })).toBe(4);
+        expect(calculateCost({ from: BOW_AND_ARROW, to: COEXISTING_CURVES })).toBe(4);
+    });
+
+    it('with straight->straight calculation', () => {
+        expect(calculateCost({ from: STRAIGHT_TIGHT, to: BOW_AND_ARROW })).toBe(4);
+        expect(calculateCost({ from: STRAIGHT_TIGHT, to: BOW_AND_ARROW, toOrientation: Direction.TOP_RIGHT })).toBe(10);
+        expect(calculateCost({ from: BOW_AND_ARROW, to: STRAIGHT_TIGHT })).toBe(4);
+        expect(calculateCost({ from: BOW_AND_ARROW, to: BOW_AND_ARROW, toOrientation: Direction.TOP_RIGHT })).toBe(10);
+    });
+  });
+});

--- a/src/maps/pittsburgh/build_cost_test.ts
+++ b/src/maps/pittsburgh/build_cost_test.ts
@@ -114,11 +114,11 @@ describe(PittsburghFunkyBuilding.name, () => {
         expect(calculateCost({ from: SimpleTileType.TIGHT, to: SimpleTileType.STRAIGHT })).toBe(10);
     });
 
-    it('to non-straight (costs $3)', () => {
-        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: SimpleTileType.CURVE })).toBe(3);
-        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: SimpleTileType.TIGHT })).toBe(3);
-        expect(calculateCost({ from: SimpleTileType.TIGHT, to: SimpleTileType.CURVE })).toBe(3);
-        expect(calculateCost({ from: SimpleTileType.CURVE, to: SimpleTileType.TIGHT })).toBe(3);
+    it('to non-straight (costs $4)', () => {
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: SimpleTileType.CURVE })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.STRAIGHT, to: SimpleTileType.TIGHT })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.TIGHT, to: SimpleTileType.CURVE })).toBe(4);
+        expect(calculateCost({ from: SimpleTileType.CURVE, to: SimpleTileType.TIGHT })).toBe(4);
     });
   });
 


### PR DESCRIPTION
## Fix track cost calculations on Pittsburgh

The Pittsburgh map has a simplified cost model for track builds (compared to base Age of Steam rules). They are as follows:
- Towns (including town upgrades): `$0`
- Straight track (including redirects to straight): `$10`
- Non-straight simple track (including redirects to non-straight): `$3`
- Complex track:
  - Upgraded track that introduces a straight segment: `$10`
  - All other complex upgrades: `$4`

On this map, any track configuration that introduces a straight segment should cost `$10`. This applies to simple straight track, complex track that adds a straight segment, and redirects that result in a new straight segment.

The engine's `getComplexUpgradeCost()` hook only fires when the resulting track crosses itself, so it can't express Pittsburgh's rules on its own. This would sometimes cause upgrade to fall through to base redirect logic and lead to unfairly cheap straight track at `$2`, or even prohibitively expensive track at `$20` (see regression tests).

### Solution
Complex upgrades had to be isolated from the engine's hooks entirely. Each tile upgrade permutation is enumerated explicitly through `costOf()`, with all other cases delegated back to the base engine.

Pittsburgh's overridden `costOf()` now first identifies complex upgrades and defaults back to `super.costOf()` for everything else (first-tile placement, town->town, simple->simple, complex->simple). For complex upgrades, cost is determined by whether the old/new tile types contain a straight segment (`containsStraight()`):
- Unambiguous cases (straight added, removed, or absent on both) are priced directly
- Ambiguous cases (straight->straight) use `countRedirects()` to select the right cost table, both for simple and complex origin tiles

With this change, `getComplexUpgradeCost()` was no longer needed, and `getRedirectCost()` was simplified to only check simple->simple redirects.

### Additional Cleanup
- Added `containsStraight()` to centralize straight segment checks
- Added `getTownTileCost()` and `getCostOfLandTypeForTown()` to override default town costs
- Exported `countRedirects()` from the base `BuildCostCalculator` (was private). Flagging this for review, not sure if it's okay to share this logic or if I need to reimplement

### Testing
Added `build_cost_test.ts` covering first-tile placement, town upgrades, simple rerouting, and simple/complex upgrades split by unambiguous vs. ambiguous cases.