### PR TITLE
Fix crash when a map removes a tile type from its manifest

### DIFF
--- a/src/engine/build/helper.ts
+++ b/src/engine/build/helper.ts
@@ -102,7 +102,7 @@ export class BuilderHelper {
         townTiles.set(tile, (townTiles.get(tile) ?? 0) + 1);
         continue;
       }
-      const entry = manifest.get(tile)!;
+      const entry = entryFor(manifest, tile);
       manifest.set(tile, {
         remaining: entry.remaining - 1,
         remainingIgnoringTowns: entry.remainingIgnoringTowns - 1,
@@ -113,11 +113,11 @@ export class BuilderHelper {
       const options = this.getTileOptions(tile);
       let i = count;
       while (i > 0) {
-        const newType = options.find((type) => manifest.get(type)!.remaining > 0);
+        const newType = options.find((type) => entryFor(manifest, type).remaining > 0);
         // If we can't find an available one, then oh well, just pick one and we'll mark it as negative.
         if (newType == null) {
           const newType2 = options[0];
-          const entry = manifest.get(newType2)!;
+          const entry = entryFor(manifest, newType2);
           manifest.set(newType2, {
             ...entry,
             remaining: entry.remaining - count,
@@ -125,7 +125,7 @@ export class BuilderHelper {
           break;
         }
 
-        const entry = manifest.get(newType)!;
+        const entry = entryFor(manifest, newType);
         manifest.set(newType, {
           ...entry,
           remaining: Math.max(entry.remaining - i, 0),
@@ -190,4 +190,24 @@ export interface TileManifestEntry {
 
 function toManifestEntry(count: number): TileManifestEntry {
   return {remaining: count, remainingIgnoringTowns: count};
+}
+
+/**
+ * The manifest entry for a tile type, treating an absent one as out of stock.
+ *
+ * A map may drop a tile type from its manifest entirely -- Pittsburgh removes
+ * ComplexTileType.X -- which means it stocks none of them. Reading the entry
+ * directly then dereferenced undefined and threw a TypeError, which surfaced as
+ * a 500 rather than the validation error callers expect. Note this is reachable
+ * in ordinary play and not only by asking for the removed tile directly:
+ * TownTileType.X resolves through getTileOptions to ComplexTileType.X, so
+ * building a town X tile on Pittsburgh hit it too.
+ *
+ * A zero count makes the tile unavailable, which every caller already handles.
+ */
+function entryFor(
+  manifest: Map<TileType, TileManifestEntry>,
+  tile: TileType,
+): TileManifestEntry {
+  return manifest.get(tile) ?? { remaining: 0, remainingIgnoringTowns: 0 };
 }

--- a/src/engine/build/helper_test.ts
+++ b/src/engine/build/helper_test.ts
@@ -1,0 +1,87 @@
+import { setInjectionContext } from "../framework/execution_context";
+import { InjectionContext } from "../framework/inject";
+import { StateStore } from "../framework/state";
+import { GameMemory } from "../game/game_memory";
+import { GRID, INTER_CITY_CONNECTIONS } from "../game/state";
+import { ComplexTileType, SimpleTileType, TownTileType } from "../state/tile";
+import { BuilderHelper } from "./helper";
+
+/**
+ * Pittsburgh removes ComplexTileType.X from its tile manifest, which used to
+ * make BuilderHelper dereference a missing entry and throw a TypeError.
+ *
+ * That was reachable in ordinary play: TownTileType.X resolves through
+ * getTileOptions to ComplexTileType.X, so a player building a town X tile on
+ * Pittsburgh hit it, and the server answered with a 500 instead of a validation
+ * error.
+ */
+describe("BuilderHelper tile manifest", () => {
+  function helperFor(gameKey: string): BuilderHelper {
+    const context = new InjectionContext(gameKey);
+    setInjectionContext(context);
+    try {
+      context.get(GameMemory).setGame({ id: 1, gameKey, variant: {} });
+      const state = context.get(StateStore);
+      state.init(GRID, new Map());
+      state.init(INTER_CITY_CONNECTIONS, []);
+      return context.get(BuilderHelper);
+    } finally {
+      setInjectionContext();
+    }
+  }
+
+
+  describe("on a map that stocks every tile", () => {
+    it("reports common tiles as available", () => {
+      const helper = helperFor("rust-belt");
+
+      expect(helper.tileAvailableInManifest(SimpleTileType.STRAIGHT)).toBe(true);
+      expect(helper.tileAvailableInManifest(ComplexTileType.X)).toBe(true);
+      expect(helper.tileAvailableInManifest(TownTileType.X)).toBe(true);
+    });
+  });
+
+  describe("on Pittsburgh, which removes ComplexTileType.X", () => {
+    it("reports the removed tile as unavailable instead of throwing", () => {
+      const helper = helperFor("pittsburgh");
+
+      expect(() =>
+        helper.tileAvailableInManifest(ComplexTileType.X),
+      ).not.toThrow();
+      expect(helper.tileAvailableInManifest(ComplexTileType.X)).toBe(false);
+    });
+
+    it("handles a town tile that resolves to the removed tile", () => {
+      const helper = helperFor("pittsburgh");
+
+      // TownTileType.X's options are [ComplexTileType.X, COEXISTING_CURVES].
+      // The removed one must be skipped rather than dereferenced.
+      expect(() => helper.tileAvailableInManifest(TownTileType.X)).not.toThrow();
+      expect(helper.tileAvailableInManifest(TownTileType.X)).toBe(true);
+    });
+
+    it("still stocks the tiles it did not remove", () => {
+      const helper = helperFor("pittsburgh");
+
+      expect(helper.tileAvailableInManifest(SimpleTileType.STRAIGHT)).toBe(true);
+      expect(helper.tileAvailableInManifest(SimpleTileType.CURVE)).toBe(true);
+      expect(
+        helper.tileAvailableInManifest(ComplexTileType.COEXISTING_CURVES),
+      ).toBe(true);
+    });
+
+    it("can build its whole manifest without throwing", () => {
+      const helper = helperFor("pittsburgh");
+      const everyTileType = [
+        ...Object.values(SimpleTileType),
+        ...Object.values(TownTileType),
+        ...Object.values(ComplexTileType),
+      ].filter((value): value is number => typeof value === "number");
+
+      for (const tileType of everyTileType) {
+        expect(() => helper.tileAvailableInManifest(tileType)).not.toThrow();
+      }
+    });
+  });
+
+});


### PR DESCRIPTION
BuilderHelper.calculateManifest read manifest entries with a non-null
assertion. A map may drop a tile type from its manifest entirely --
Pittsburgh removes ComplexTileType.X -- and the lookup then dereferenced
undefined, throwing "Cannot read properties of undefined (reading
'remaining')".

This is reachable in ordinary play, not only by asking for the removed
tile directly. TownTileType.X resolves through getTileOptions to
[ComplexTileType.X, COEXISTING_CURVES], and the availability scan reads
the first option's entry before it can skip it, so a player building a
town X tile on Pittsburgh hit it. tileAvailableInManifest is called from
BuildAction.validate, so the request failed with a 500 instead of the
validation error the client expects and renders.

A tile type absent from the manifest means the map stocks none of them,
so entryFor() now treats it as a zero count. Every caller already
handles a tile being unavailable: the direct build is rejected as
invalid input, and the town-tile scan skips the missing option and
correctly falls through to COEXISTING_CURVES.

Adds a regression test covering the removed tile, the town tile that
resolves to it, the tiles Pittsburgh does still stock, and a sweep over
every tile type. Verified the test fails with 3 TypeErrors before the
fix and passes after.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
