### PR TITLE
Fix Alabama Railways setup not being reproducible from its seed

### DIFF
--- a/src/maps/alabama_railways/starter.ts
+++ b/src/maps/alabama_railways/starter.ts
@@ -2,7 +2,7 @@ import { GameStarter } from "../../engine/game/starter";
 import { CityGroup } from "../../engine/state/city_group";
 import { Good } from "../../engine/state/good";
 import { OnRoll } from "../../engine/state/roll";
-import { infiniteLoopCheck } from "../../utils/functions";
+import { assert } from "../../utils/validate";
 
 export class AlabamaRailwaysStarter extends GameStarter {
   protected startingBag(): Good[] {
@@ -25,15 +25,20 @@ export class AlabamaRailwaysStarter extends GameStarter {
     const normalized = Array.isArray(cityColor) ? cityColor : [cityColor];
     const array: Good[] = [];
     for (let i = 0; i < (urbanized ? 2 : 3); i++) {
-      let index: number;
-      let good: Good;
-      const loop = infiniteLoopCheck(15);
-      do {
-        loop();
-        index = Math.floor(Math.random() * bag.length);
-        good = bag[index];
-      } while (good !== Good.BLACK && normalized.includes(good));
-      array.push(good);
+      // The bag arrives already shuffled by the seeded Random, so scan it from
+      // the end for the first acceptable cube -- matching draw()'s
+      // pop-from-the-end convention -- rather than sampling. This previously
+      // used Math.random(), which made setup unreproducible from a seed.
+      let index = -1;
+      for (let candidate = bag.length - 1; candidate >= 0; candidate--) {
+        const good = bag[candidate];
+        if (good === Good.BLACK || !normalized.includes(good)) {
+          index = candidate;
+          break;
+        }
+      }
+      assert(index >= 0, "no acceptable goods growth cube left in the bag");
+      array.push(bag[index]);
       bag.splice(index, 1);
     }
     return array;

--- a/src/maps/alabama_railways/starter_test.ts
+++ b/src/maps/alabama_railways/starter_test.ts
@@ -1,0 +1,60 @@
+import { EngineDelegator } from "../../engine/framework/engine";
+import { Good } from "../../engine/state/good";
+
+/**
+ * Alabama Railways setup has to be reproducible from the seed.
+ *
+ * The engine's convention is that the bag is shuffled once with the seeded
+ * generator and then drawn from deterministically, so a game's setup is fixed by
+ * its seed. This map used to pick its goods growth cubes with Math.random(),
+ * which no seed can control.
+ */
+describe("Alabama Railways setup", () => {
+  const GAME_KEY = "alabama-railways";
+
+  function start(seed: string) {
+    return JSON.parse(
+      EngineDelegator.singleton.start({
+        game: { id: 1, gameKey: GAME_KEY, variant: {} },
+        players: [{ playerId: 1 }, { playerId: 2 }],
+        seed,
+      }).gameData,
+    ).gameData;
+  }
+
+  it("deals the same board every time for a given seed", () => {
+    for (const seed of ["a", "b", "c"]) {
+      expect(start(seed)).toEqual(start(seed));
+    }
+  });
+
+  it("deals a different board for a different seed", () => {
+    expect(start("seed-a")).not.toEqual(start("seed-b"));
+  });
+
+  it("never puts a city's own colour in its goods growth, except black", () => {
+    // The rule the original sampling loop implemented, preserved by the scan
+    // that replaced it.
+    const state = start("colours");
+    for (const [, space] of state.grid as Array<
+      [unknown, { color?: Good | Good[]; onRoll?: Array<{ goods: Good[] }> }]
+    >) {
+      if (space.onRoll == null || space.color == null) continue;
+      const own = Array.isArray(space.color) ? space.color : [space.color];
+      for (const onRoll of space.onRoll) {
+        for (const good of onRoll.goods) {
+          if (good === Good.BLACK) continue;
+          expect(own).not.toContain(good);
+        }
+      }
+    }
+  });
+
+  it("never deals the goods this map removes from the bag", () => {
+    const state = start("bag");
+    const inBag = state.bag as Good[];
+
+    expect(inBag).not.toContain(Good.YELLOW);
+    expect(inBag).not.toContain(Good.PURPLE);
+  });
+});


### PR DESCRIPTION
`AlabamaRailwaysStarter.getGoodsGrowthGoodsFor` sampled the bag with `Math.random()` — the only such call in the engine or any map.

The engine's convention is that the bag is shuffled once with the seeded `Random` and then drawn from the end, so a game's setup is determined entirely by its seed. This map was not: the same seed dealt a different board each time.

It now scans the pre-shuffled bag from the end for the first acceptable cube, matching `draw()`'s pop-from-the-end convention and preserving the original intent — take BLACK, otherwise reject the city's own colours.

### Distribution is preserved

Taking the last acceptable cube from a uniformly shuffled bag has the same distribution as the rejection sampling it replaces: by exchangeability, each acceptable cube is equally likely to be the last acceptable one. That holds for each successive draw too, since splicing preserves the shuffle of the remainder.

### The `infiniteLoopCheck` guard is gone

It only existed to bound rejection sampling *with replacement*, which could retry forever if the bag held no acceptable cube. A linear scan touches each cube at most once, so looping is structurally impossible, and the case the guard was catching is now an explicit `assert` with a clearer message.

The scan is also strictly more robust: the old loop could give up after fifteen unlucky picks even when an acceptable cube existed.

### Notes

- This changes which cubes a given seed produces on this map, but there was nothing reproducible to preserve, and games already played keep their stored setup.
- The test was confirmed to fail without the fix (`deals the same board every time for a given seed`).
- Found by a check that starts every registered map twice and compares the results, from ongoing work on a test harness.