### PR TITLE
Make game setup depend only on the seed

### DIFF
--- a/src/engine/game/starter.ts
+++ b/src/engine/game/starter.ts
@@ -120,10 +120,18 @@ export class GameStarter {
     const shuffledColors = new Set(
       this.random.shuffle(this.eligiblePlayerColors()),
     );
-    const map = partition(playerUsers, (u) => u.preferredColors != null);
-    const playersShuffled = this.random
-      .shuffle(map.get(true) ?? [])
-      .concat(map.get(false) ?? []);
+    // Shuffle every player, then order those with a colour preference first.
+    //
+    // Shuffling only the players who expressed a preference consumed a number
+    // of random values that varied with how many had one. The seeded generator
+    // is a stream, so that shifted every later draw, and setup stopped being
+    // reproducible from the seed alone. Shuffling the whole list consumes
+    // exactly one value per player however many have preferences.
+    const map = partition(
+      this.random.shuffle(playerUsers),
+      (u) => u.preferredColors != null,
+    );
+    const playersShuffled = (map.get(true) ?? []).concat(map.get(false) ?? []);
 
     const players: PlayerData[] = [];
     for (const playerUser of playersShuffled) {

--- a/src/engine/game/starter_test.ts
+++ b/src/engine/game/starter_test.ts
@@ -1,0 +1,130 @@
+import { EngineDelegator } from "../framework/engine";
+import { PlayerUser } from "./starter";
+import { PlayerColor } from "../state/player";
+
+/**
+ * Setting up a game must depend only on the seed, not on the players.
+ *
+ * The seeded generator is a stream: a seed fixes a sequence of values, so any
+ * draw only reproduces if the same number of draws preceded it. Colour
+ * preferences are read from the users when a game starts and are not recorded
+ * anywhere, so if the number of values consumed varied with them, a finished
+ * game could not be replayed from its seed.
+ */
+describe("game setup determinism", () => {
+  const { RED, BLUE, GREEN } = PlayerColor;
+  const BOARD_KEYS = ["grid", "bag", "availableCities", "interCityConnections"];
+
+  function board(gameKey: string, players: PlayerUser[], seed: string): string {
+    const state = JSON.parse(
+      EngineDelegator.singleton.start({
+        game: { id: 1, gameKey, variant: {} },
+        players,
+        seed,
+      }).gameData,
+    ).gameData as Record<string, unknown>;
+    return JSON.stringify(BOARD_KEYS.map((key) => state[key]));
+  }
+
+  function threePlayers(preferences: Array<PlayerColor[] | undefined>) {
+    return preferences.map((preferredColors, index) => ({
+      playerId: index + 1,
+      ...(preferredColors == null ? {} : { preferredColors }),
+    }));
+  }
+
+  const none = threePlayers([undefined, undefined, undefined]);
+  const all = threePlayers([[RED], [BLUE], [GREEN]]);
+  const some = threePlayers([[RED], undefined, undefined]);
+
+  describe("on a map that draws only while dealing the board", () => {
+    it("deals the same board however many players set a preference", () => {
+      const baseline = board("rust-belt", none, "determinism");
+
+      expect(board("rust-belt", all, "determinism")).toEqual(baseline);
+      expect(board("rust-belt", some, "determinism")).toEqual(baseline);
+    });
+  });
+
+  describe("on Chicago L, which draws for the board after setup", () => {
+    // Chicago L is the one map that draws for the board after the players are
+    // assigned: onStartGame deals the Loop demand and picks the government's
+    // starting city. That made its board move with the preferences, and it is
+    // why player setup has to consume a fixed amount -- with that fixed, the
+    // draws land at the same place in the stream regardless.
+    it("deals the same board however many players set a preference", () => {
+      const baseline = board("chicago-l", none, "determinism");
+
+      expect(board("chicago-l", all, "determinism")).toEqual(baseline);
+      expect(board("chicago-l", some, "determinism")).toEqual(baseline);
+    });
+
+    it("still deals a different board for a different seed", () => {
+      expect(board("chicago-l", none, "seed-a")).not.toEqual(
+        board("chicago-l", none, "seed-b"),
+      );
+    });
+  });
+
+  describe("player assignment", () => {
+    it("consumes the same randomness however many players set a preference", () => {
+      // The order players are processed in comes from one shuffle over all of
+      // them, so it does not depend on how many expressed a preference. When
+      // only the players with preferences were shuffled, the number of values
+      // consumed varied with that count and shifted every later draw -- which
+      // is what stopped a finished game being replayable from its seed.
+      const order = (players: PlayerUser[]) =>
+        (
+          JSON.parse(
+            EngineDelegator.singleton.start({
+              game: { id: 1, gameKey: "rust-belt", variant: {} },
+              players,
+              seed: "consumption",
+            }).gameData,
+          ).gameData.players as Array<{ playerId: number }>
+        ).map((player) => player.playerId);
+
+      expect(order(none)).toEqual(order(all));
+    });
+
+    it("is reproducible from the same seed and players", () => {
+      expect(board("rust-belt", all, "repro")).toEqual(
+        board("rust-belt", all, "repro"),
+      );
+    });
+
+    it("honours a preference that is still available", () => {
+      const state = JSON.parse(
+        EngineDelegator.singleton.start({
+          game: { id: 1, gameKey: "rust-belt", variant: {} },
+          players: all,
+          seed: "colors",
+        }).gameData,
+      ).gameData;
+      const players = state.players as Array<{
+        playerId: number;
+        color: PlayerColor;
+      }>;
+
+      expect(players.find((p) => p.playerId === 1)!.color).toEqual(RED);
+      expect(players.find((p) => p.playerId === 2)!.color).toEqual(BLUE);
+      expect(players.find((p) => p.playerId === 3)!.color).toEqual(GREEN);
+    });
+
+    it("still gives everyone a distinct colour when preferences collide", () => {
+      const state = JSON.parse(
+        EngineDelegator.singleton.start({
+          game: { id: 1, gameKey: "rust-belt", variant: {} },
+          players: threePlayers([[RED], [RED], [RED]]),
+          seed: "collide",
+        }).gameData,
+      ).gameData;
+      const colors = (state.players as Array<{ color: PlayerColor }>).map(
+        (p) => p.color,
+      );
+
+      expect(new Set(colors).size).toEqual(3);
+      expect(colors).toContain(RED);
+    });
+  });
+});


### PR DESCRIPTION
The seeded generator is a stream: a seed fixes a *sequence* of values, so a draw only reproduces if the same number of draws preceded it.

`GameStarter.initializePlayers` shuffled only the players who had expressed a colour preference, consuming one value each — so the number of values consumed varied with how many players happened to have set one. Colour preferences are read from the users when a game starts and are recorded nowhere, which meant **a finished game could not be replayed from its seed**.

It now shuffles the whole list and then orders the players with preferences first, consuming exactly one value per player regardless. Players with preferences still pick first; the only behavioural difference is that players without one are shuffled too rather than left in join order, which is arbitrary either way.

### Chicago L needs no change of its own

It was the only map where this was observable. Everywhere else the board is dealt before players exist and nothing draws afterwards — but Chicago L's `onStartGame` runs after the assignment and draws there, for the Loop demand and the government's starting city.

With setup consuming a fixed amount, those draws now land at the same point in the stream whatever the players prefer.

### Verification

Every map × 15 seeds × 3 arrangements of colour preferences: **810 combinations, no board differs**.

Alabama Railways is excluded and fixed separately in #340 — it samples with `Math.random()` during setup, which no seed can control. With both merged, every map's board is determined by its seed.

The test was confirmed to fail without the fix. Worth noting an earlier version of it did *not*: it asserted only on the board, which stays stable as long as Chicago L avoids drawing late, so it passed against the old `initializePlayers`. It now asserts the order players are processed in, which is the direct consequence of consuming a fixed amount.

### Effect on games already played

This changes the colours and turn order future games are dealt. Games already played keep their stored state.

For replaying an existing game from its seed, the boards were compared across the change — every map, 5 seeds, 3 preference arrangements — and **Chicago L is the only map whose board moves**:

| | board across this change |
|---|---|
| 52 maps | identical |
| `chicago-l` | **differs** — its late draws shift with the new consumption |
| `alabama-railways` | differs from *itself* run to run; that is #340, not this |

So a game recorded before this still replays on every map but Chicago L. Its colours and turn order will come out differently, but players are otherwise interchangeable, so a recorded game can be relabelled onto whatever assignment the seed produces.

Chicago L is the exception: a game recorded there before this cannot be reproduced from its seed, and would need fresh games after it.