### PR TITLE
Add an endpoint that exports a game as replayable actions

### DIFF
--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -1,0 +1,64 @@
+import { initContract } from "@ts-rest/core";
+import z from "zod";
+import { GameIdParams } from "./game";
+import { GameKeyZod } from "./game_key";
+import { VariantConfig } from "./variant_config";
+
+/**
+ * A game reduced to what is needed to replay it.
+ *
+ * Replaying starts a fresh game from `seed` and re-emits `actions` in order.
+ * Everything else about setup follows from the seed, so nothing about the board
+ * has to be captured: the engine uses no clock and no unseeded randomness, and
+ * player colour preferences -- the one input that is not the seed -- only affect
+ * which player holds which colour, not the board.
+ *
+ * Colours therefore need not be exported. A replay deals whatever colours the
+ * seed produces, and since players are otherwise interchangeable, a consumer
+ * relabels the recorded game onto that assignment.
+ */
+const GameExportAction = z.object({
+  /** The version of the game this action was applied to. */
+  version: z.number(),
+  actionName: z.string(),
+  /** The action's payload, as the client sent it. */
+  actionData: z.unknown(),
+  /**
+   * The seed in force for this action, or null if it needed no randomness.
+   *
+   * Recorded per action rather than per game: the engine generates one lazily
+   * the first time an action draws.
+   */
+  seed: z.string().nullable(),
+});
+
+export const GameExportApi = z.object({
+  id: z.number(),
+  gameKey: GameKeyZod,
+  variant: VariantConfig,
+  /** Player ids in the order they were handed to the engine at start. */
+  playerIds: z.array(z.number()),
+  /** The seed the game was started with. */
+  startSeed: z.string().nullable(),
+  /**
+   * The state immediately after setup, as the engine serialized it.
+   *
+   * Only needed to check that a replay from the seed reproduced the same
+   * opening. A consumer that trusts the seed can ignore it.
+   */
+  startState: z.string().nullable(),
+  actions: z.array(GameExportAction),
+});
+export type GameExportApi = z.infer<typeof GameExportApi>;
+
+export const gameExportContract = initContract().router({
+  get: {
+    method: "GET",
+    pathParams: GameIdParams,
+    path: "/games/:gameId/export",
+    responses: {
+      200: z.object({ game: GameExportApi }),
+    },
+    summary: "Export a game as a replayable list of actions",
+  },
+});

--- a/src/server/game/export.ts
+++ b/src/server/game/export.ts
@@ -1,0 +1,57 @@
+import { GameExportApi } from "../../api/export";
+import { GameKey } from "../../api/game_key";
+import { VariantConfig } from "../../api/variant_config";
+
+/** The parts of a game the export needs. */
+export interface ExportableGame {
+  id: number;
+  gameKey: GameKey;
+  variant: VariantConfig;
+  playerIds: number[];
+}
+
+/** The parts of a history row the export needs. */
+export interface ExportableHistory {
+  previousGameVersion: number;
+  previousGameData: string | null;
+  actionName: string | null;
+  actionData: string | null;
+  seed: string | null;
+}
+
+/**
+ * Reduces a game and its history to a replayable form.
+ *
+ * Separated from the route so it can be tested without a database.
+ */
+export function toGameExport(
+  game: ExportableGame,
+  histories: ExportableHistory[],
+): GameExportApi {
+  const ordered = [...histories].sort(
+    (a, b) => a.previousGameVersion - b.previousGameVersion,
+  );
+
+  // Starting a game writes a history row of its own: it carries the seed but no
+  // action. Rows with an action are the ones that were applied.
+  const start = ordered.find((history) => history.actionName == null);
+  const applied = ordered.filter((history) => history.actionName != null);
+
+  return {
+    id: game.id,
+    gameKey: game.gameKey,
+    variant: game.variant,
+    playerIds: game.playerIds,
+    startSeed: start?.seed ?? null,
+    // The state each action was applied to, so the first action's is the state
+    // immediately after setup.
+    startState: applied[0]?.previousGameData ?? null,
+    actions: applied.map((history) => ({
+      version: history.previousGameVersion,
+      actionName: history.actionName!,
+      actionData:
+        history.actionData == null ? undefined : JSON.parse(history.actionData),
+      seed: history.seed ?? null,
+    })),
+  };
+}

--- a/src/server/game/export_routes.ts
+++ b/src/server/game/export_routes.ts
@@ -1,0 +1,41 @@
+import { createExpressEndpoints, initServer } from "@ts-rest/express";
+import express from "express";
+import { gameExportContract } from "../../api/export";
+import { UserRole } from "../../api/user";
+import { assert } from "../../utils/validate";
+import { assertRole } from "../util/enforce_role";
+import { GameDao } from "./dao";
+import { toGameExport } from "./export";
+import { GameHistoryDao } from "./history_dao";
+
+export const gameExportApp = express();
+
+/**
+ * Exports a finished game as the list of actions that produced it.
+ *
+ * The intended consumer is the test corpus: each exported game becomes a
+ * regression test that replays it from its seed. The existing history endpoint
+ * is not enough for that -- it returns the state at each step but not the action
+ * data or the seed that produced it.
+ *
+ * Admin only. It is a tooling endpoint, and it exposes every player's moves for
+ * a game that may still be running, which the normal history view does not.
+ */
+const router = initServer().router(gameExportContract, {
+  async get({ req, params }) {
+    await assertRole(req, UserRole.enum.ADMIN);
+
+    const [game, histories] = await Promise.all([
+      GameDao.findByPk(params.gameId),
+      GameHistoryDao.findAll({
+        where: { gameId: params.gameId },
+        order: [["previousGameVersion", "ASC"]],
+      }),
+    ]);
+    assert(game != null, { notFound: true });
+
+    return { status: 200, body: { game: toGameExport(game, histories) } };
+  },
+});
+
+createExpressEndpoints(gameExportContract, router, gameExportApp);

--- a/src/server/game/export_test.ts
+++ b/src/server/game/export_test.ts
@@ -1,0 +1,125 @@
+import { ExportableGame, ExportableHistory, toGameExport } from "./export";
+
+/**
+ * The export exists so a finished game can become a replayable regression test,
+ * so the shape it produces has to line up with how a game is actually recorded:
+ * starting a game writes a history row carrying the seed but no action, and each
+ * later row carries an action plus the state it was applied to.
+ */
+describe("toGameExport", () => {
+  const game: ExportableGame = {
+    id: 7,
+    gameKey: "rust-belt",
+    variant: { baseRules: true },
+    playerIds: [10, 20, 30],
+  };
+
+  function history(
+    overrides: Partial<ExportableHistory> & { previousGameVersion: number },
+  ): ExportableHistory {
+    return {
+      previousGameData: null,
+      actionName: null,
+      actionData: null,
+      seed: null,
+      ...overrides,
+    };
+  }
+
+  const startRow = history({ previousGameVersion: 1, seed: "start-seed" });
+  const firstAction = history({
+    previousGameVersion: 2,
+    actionName: "takeShares",
+    actionData: '{"numShares":2}',
+    seed: "seed-a",
+    previousGameData: '{"version":3,"gameData":{}}',
+  });
+  const secondAction = history({
+    previousGameVersion: 3,
+    actionName: "pass",
+    actionData: "{}",
+    seed: null,
+  });
+
+  it("carries the game's identity and setup", () => {
+    const exported = toGameExport(game, [startRow, firstAction]);
+
+    expect(exported.id).toEqual(7);
+    expect(exported.gameKey).toEqual("rust-belt");
+    expect(exported.variant).toEqual({ baseRules: true });
+    expect(exported.playerIds).toEqual([10, 20, 30]);
+  });
+
+  it("takes the start seed from the row that has no action", () => {
+    const exported = toGameExport(game, [startRow, firstAction, secondAction]);
+
+    expect(exported.startSeed).toEqual("start-seed");
+  });
+
+  it("excludes the start row from the actions", () => {
+    const exported = toGameExport(game, [startRow, firstAction, secondAction]);
+
+    expect(exported.actions.map((action) => action.actionName)).toEqual([
+      "takeShares",
+      "pass",
+    ]);
+  });
+
+  it("parses action data back into a value", () => {
+    const exported = toGameExport(game, [startRow, firstAction]);
+
+    expect(exported.actions[0].actionData).toEqual({ numShares: 2 });
+  });
+
+  it("keeps each action's own seed, including when it needed none", () => {
+    const exported = toGameExport(game, [startRow, firstAction, secondAction]);
+
+    // The engine generates a seed lazily, the first time an action draws, so an
+    // action that needed no randomness records none. Replay has to preserve
+    // that rather than substitute the game's start seed.
+    expect(exported.actions[0].seed).toEqual("seed-a");
+    expect(exported.actions[1].seed).toBeNull();
+  });
+
+  it("reports the state the first action was applied to as the start state", () => {
+    const exported = toGameExport(game, [startRow, firstAction, secondAction]);
+
+    // That is the state immediately after setup, which is what a replay from
+    // the seed should reproduce.
+    expect(exported.startState).toEqual('{"version":3,"gameData":{}}');
+  });
+
+  it("orders actions by version whatever order the rows arrive in", () => {
+    const exported = toGameExport(game, [secondAction, firstAction, startRow]);
+
+    expect(exported.actions.map((action) => action.version)).toEqual([2, 3]);
+  });
+
+  it("handles a game that was started but never played", () => {
+    const exported = toGameExport(game, [startRow]);
+
+    expect(exported.actions).toEqual([]);
+    expect(exported.startSeed).toEqual("start-seed");
+    expect(exported.startState).toBeNull();
+  });
+
+  it("handles a game with no history at all", () => {
+    const exported = toGameExport(game, []);
+
+    expect(exported.actions).toEqual([]);
+    expect(exported.startSeed).toBeNull();
+    expect(exported.startState).toBeNull();
+  });
+
+  it("tolerates an action row that recorded no data", () => {
+    const noData = history({
+      previousGameVersion: 2,
+      actionName: "pass",
+      actionData: null,
+    });
+    const exported = toGameExport(game, [startRow, noData]);
+
+    expect(exported.actions[0].actionName).toEqual("pass");
+    expect(exported.actions[0].actionData).toBeUndefined();
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8,6 +8,7 @@ import { log, logError } from "../utils/functions";
 import { devApp } from "./dev/routes";
 import { feedbackApp } from "./feedback/routes";
 import { autoActionApp } from "./game/auto_action_routes";
+import { gameExportApp } from "./game/export_routes";
 import { gameHistoryApp } from "./game/history_routes";
 import { notesApp } from "./game/notes_routes";
 import { gameApp } from "./game/routes";
@@ -51,6 +52,7 @@ export async function runApp(): Promise<() => Promise<void>> {
   app.use(enforceRoleMiddleware());
   app.use("/api", gameApp);
   app.use("/api", gameHistoryApp);
+  app.use("/api", gameExportApp);
   app.use("/api", messageApp);
   app.use("/api", feedbackApp);
   app.use("/api", notesApp);


### PR DESCRIPTION
Groundwork for a regression corpus built from real games: each exported game becomes a test that replays it and checks the outcome.

`GET /api/games/:gameId/export` returns the game key, variant, player ids, the seed the game started with, and every action in order with its own payload and seed.

The existing history endpoint can't serve this — it returns the *state* at each step, but neither the action data nor the seed that produced it.

### Design notes

**Seeds are per action, not per game.** The engine generates one lazily the first time an action draws, so an action that needed no randomness records none, and replay must preserve that rather than substitute the game's start seed. Starting a game writes a history row of its own carrying the seed but no action — that's where `startSeed` comes from.

**Colours are deliberately not exported.** Setting up a game is a pure function of the seed (the engine uses no clock and no unseeded randomness), and colour preferences — the one input that isn't the seed — only move which player holds which colour. Since players are otherwise interchangeable, a replay deals whatever colours the seed produces and the consumer relabels onto that.

**`startState`** carries the state the first action was applied to, i.e. the state just after setup. Nothing needs it to replay; it's there so a consumer can verify the replay reproduced the same opening, rather than discovering a divergence several actions later as a confusing validation failure.

That check earned its keep immediately: running it against a real game turned up that **Holland under the windmill variant doesn't reproduce from its seed on code older than #341** — its `onStartGame` draws from the bag for windmills, after players are assigned. #341 fixed it going forward, but pre-#341 Holland windmill games can't be replayed, the same as Chicago L.

**Admin only.** It's a tooling endpoint, and it exposes every player's moves for a game that may still be running, which the normal history view does not.

### Testing

The transform is a pure function in its own module rather than inline in the route, so it's tested without a database: ordering, the start row being excluded from actions, per-action seeds including absent ones, a game started but never played, and a game with no history.

Also exercised against real games in a local database, which confirmed the query and ordering, and that the exported colour sequence matches the recording exactly — attached to different player ids, which is the relabelling the format expects.