### PR TITLE
Give grids a defined iteration order

### DIFF
--- a/src/engine/map/grid.ts
+++ b/src/engine/map/grid.ts
@@ -1,4 +1,4 @@
-import { Map as ImmutableMap } from "immutable";
+import { OrderedMap } from "immutable";
 import { z } from "zod";
 import { Coordinates, CoordinatesZod } from "../../utils/coordinates";
 import { deepEquals } from "../../utils/deep_equals";
@@ -27,7 +27,7 @@ export class Grid {
 
   private constructor(
     private readonly mapSettings: MapSettings,
-    private readonly grid: ImmutableMap<Coordinates, Space>,
+    private readonly grid: OrderedMap<Coordinates, Space>,
     readonly connections: InterCityConnection[],
   ) {
     const doubleHeights = [...this.keys()].map((coord) =>
@@ -299,10 +299,7 @@ export class Grid {
     gridData: GridData,
     connections: InterCityConnection[],
   ): Grid {
-    return new Grid(mapSettings, ImmutableMap(), []).merge(
-      gridData,
-      connections,
-    );
+    return new Grid(mapSettings, OrderedMap(), []).merge(gridData, connections);
   }
 
   static fromSpaces(
@@ -312,7 +309,7 @@ export class Grid {
   ): Grid {
     return new Grid(
       mapSettings,
-      ImmutableMap(spaces.map((s) => [s.coordinates, s])),
+      OrderedMap(spaces.map((s) => [s.coordinates, s])),
       connections,
     );
   }

--- a/src/engine/state/grid.ts
+++ b/src/engine/state/grid.ts
@@ -1,5 +1,22 @@
-import { Map as ImmutableMap } from "immutable";
+import { OrderedMap } from "immutable";
 import { Coordinates } from "../../utils/coordinates";
 import { CityData, LandData } from "./space";
 
-export type GridData = ImmutableMap<Coordinates, CityData | LandData>;
+/**
+ * A map's starting layout.
+ *
+ * Ordered rather than a plain Immutable Map, because the order this is iterated
+ * in decides which city gets which goods cube: GameStarter.drawCubesForCities
+ * walks it and pops from the shuffled bag as it goes.
+ *
+ * Immutable documents Map's iteration order as undefined -- it is a hash trie,
+ * and for object keys the hash is a process-local counter assigned on first use.
+ * Coordinates are interned and shared between maps, so whichever map's grid was
+ * built first claimed the low hashes and every other map's order followed from
+ * that. The board a seed dealt therefore depended on module load order, which
+ * changed whenever the set of registered maps did.
+ *
+ * OrderedMap guarantees iteration in insertion order, and factory.ts inserts by
+ * looping over each map's grid literal, so the order is now the source layout.
+ */
+export type GridData = OrderedMap<Coordinates, CityData | LandData>;

--- a/src/maps/factory.ts
+++ b/src/maps/factory.ts
@@ -1,4 +1,4 @@
-import { Map as ImmutableMap } from "immutable";
+import { OrderedMap } from "immutable";
 import { BLACK, WHITE } from "../engine/state/city_group";
 import { Good } from "../engine/state/good";
 import { GridData } from "../engine/state/grid";
@@ -98,17 +98,17 @@ export function customCity(city: Omit<CityData, "type">): CityData {
 
 export function startsLowerGrid<T>(
   array: Array<Array<T | undefined>>,
-): ImmutableMap<Coordinates, T> {
+): OrderedMap<Coordinates, T> {
   return grid(array, true);
 }
 
 export function grid<T>(
   array: Array<Array<T | undefined>>,
   startsLower = false,
-): ImmutableMap<Coordinates, T> {
+): OrderedMap<Coordinates, T> {
   const newArray = offset(array, startsLower);
 
-  return ImmutableMap<Coordinates, T>().withMutations((grid) => {
+  return OrderedMap<Coordinates, T>().withMutations((grid) => {
     for (const [q, row] of newArray.entries()) {
       for (const [r, value] of row.entries()) {
         if (value == null) continue;

--- a/src/maps/grid_order_test.ts
+++ b/src/maps/grid_order_test.ts
@@ -1,0 +1,92 @@
+import { isOrdered } from "immutable";
+import { Grid } from "../engine/map/grid";
+import { MapRegistry } from "../maps/registry";
+import { Coordinates } from "../utils/coordinates";
+
+/**
+ * Grids must iterate in a defined order.
+ *
+ * GameStarter.drawCubesForCities walks a map's starting grid and pops from the
+ * shuffled bag as it goes, so the iteration order decides which city gets which
+ * cube. Chicago L likewise picks the government's starting city by indexing into
+ * Grid.cities().
+ *
+ * Both used to be plain Immutable Maps, whose iteration order Immutable
+ * documents as undefined: they are hash tries, and the hash of an object key is
+ * a process-local counter assigned on first use. Coordinates are interned and
+ * shared between maps, so whichever map's grid was built first claimed the low
+ * hashes and every other map's order followed from that. The board a given seed
+ * dealt therefore depended on module load order, and shifted whenever the set of
+ * registered maps changed -- which is why a game recorded months ago cannot be
+ * reproduced from its seed today.
+ *
+ * These are the checks that would have caught it. An earlier attempt at proving
+ * setup was seed-determined could not: every case shared one process, and so one
+ * load order.
+ */
+describe("grid iteration order", () => {
+  const ALL_MAPS = [...MapRegistry.singleton.values()].sort((a, b) =>
+    a.key < b.key ? -1 : 1,
+  );
+
+  it("covers every registered map", () => {
+    expect(ALL_MAPS.length).toBeGreaterThan(20);
+  });
+
+  for (const settings of ALL_MAPS) {
+    describe(settings.key, () => {
+      it("has a starting grid with a defined iteration order", () => {
+        // False for a plain Immutable Map, true for an OrderedMap. Asserted
+        // directly rather than by observing an order, so switching the type back
+        // fails here rather than somewhere subtle downstream.
+        expect(isOrdered(settings.startingGrid)).toBe(true);
+      });
+
+      it("iterates its starting grid in the order the map declares it", () => {
+        // factory.ts inserts by looping over the grid literal, column then row,
+        // so insertion order -- and therefore iteration order -- is the source
+        // layout. A hash-ordered map would not match this.
+        const keys = [...settings.startingGrid.keys()];
+        const expected = [...keys].sort((a, b) =>
+          a.q !== b.q ? a.q - b.q : a.r - b.r,
+        );
+
+        expect(keys.map(describe_)).toEqual(expected.map(describe_));
+      });
+
+      it("builds a runtime grid with a defined iteration order", () => {
+        const grid = Grid.fromData(
+          settings,
+          settings.startingGrid,
+          settings.interCityConnections ?? [],
+        );
+
+        // Chicago L indexes into cities() with the seeded generator, so this
+        // order has to be defined too, not just the starting grid's.
+        expect([...grid.keys()].map(describe_)).toEqual(
+          [...settings.startingGrid.keys()].map(describe_),
+        );
+      });
+
+      it("orders cities consistently with the grid", () => {
+        const grid = Grid.fromData(
+          settings,
+          settings.startingGrid,
+          settings.interCityConnections ?? [],
+        );
+        const cityOrder = grid
+          .cities()
+          .map((city) => describe_(city.coordinates));
+        const gridOrder = [...grid.keys()]
+          .filter((coordinates) => cityOrder.includes(describe_(coordinates)))
+          .map(describe_);
+
+        expect(cityOrder).toEqual(gridOrder);
+      });
+    });
+  }
+});
+
+function describe_(coordinates: Coordinates): string {
+  return coordinates.serialize();
+}


### PR DESCRIPTION
`GameStarter.drawCubesForCities` walks a map's starting grid and pops from the shuffled bag as it goes, so **iteration order decides which city gets which goods cube**. Chicago L likewise picks the government's starting city by indexing into `Grid.cities()`.

Both grids were plain Immutable `Map`s, whose iteration order Immutable documents as *undefined* (`immutable.d.ts:689`):

> Iteration order of a Map is undefined, however is stable. Multiple iterations of the same Map will iterate in the same order.

"Stable" means repeated iterations of one instance agree — not that the order is defined.

### Why the order moved

`Map` is a hash trie, and for an object key the hash comes from `hashJSObj`, which assigns a **process-local counter** (`++_objHashUID`) on first use. `Coordinates` are interned by `Coordinates.from`, so they're *shared between maps* — whichever map's grid is built first claims the low hashes, and every other map's iteration order follows from that. `MapRegistry` imports every map at startup, so the order was fixed for a given build but changed whenever the set of registered maps did.

Demonstrated directly: importing Germany's grid before Rust Belt's completely reorders Rust Belt.

```
rust-belt alone      : Cincinnati,Evansville,Toronto,Kansas City,Detroit,...
after germany loaded : Des Moines,Detroit,Wheeling,Chicago,Evansville,...
```

**So the board a seed deals depends on module load order, not just the seed.** Two servers on one commit agree, but a deploy that adds a map silently changes what every existing seed deals — and a game recorded months ago can't be reproduced from its seed today. Not a gameplay bug (any assignment is a legal setup), but it makes setup unreproducible.

### The fix

`GridData` and `Grid` now use `OrderedMap`, which Immutable *does* guarantee (`immutable.d.ts:1686`):

> A type of Map that has the additional guarantee that the iteration order of entries will be the order in which they were `set()`. The iteration behavior of OrderedMap is the same as native ES6 Map.

And insertion order is itself deterministic: `GridData` is only ever built by `factory.ts`'s `grid()`, which loops over the 2-D literal in each map's `grid.ts` — no map constructs its own. So the chain from source layout to cube assignment has no implementation-defined step left.

`hashCode()`/`equals()` on `Coordinates` was considered first and rejected: it works today, but it makes the order depend on Immutable's trie layout, which the docs explicitly disclaim, so an `immutable` upgrade could silently reshuffle every board.

### Performance

Immutable warns `OrderedMap` is more expensive. Measured on the largest grid (`double-base-usa`, 340 spaces), it isn't — **2000 merges: 2158ms vs 3281ms** for the plain `Map`.

### Testing

New test asserts `isOrdered()` directly, and that each grid iterates in the order its source declares. **Reverting the type fails 109 of them.**

Worth noting the earlier `start_determinism_test` could not have caught this: every case shared one process, and so one load order. Determinism within a process was never the question.

### Note

This changes the board existing seeds deal, once. The previous order was arbitrary, so there was nothing to preserve.