### PR TITLE
Let maps carry their own UI specs, covering Denmark's instant production

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,10 +22,17 @@ const PORT = Number(process.env.PORT ?? 3001);
 const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
 
 export default defineConfig({
-  testDir: "src/e2e",
+  testDir: "src",
   // Deliberately not *_test.ts: vitest claims that suffix, and a file picked up
   // by the wrong runner fails in confusing ways.
-  testMatch: "**/*_spec.ts",
+  //
+  // Two places, matched explicitly rather than by a single src-wide glob, which
+  // would also drag in the prober -- that drives production and has its own
+  // config:
+  //   e2e/     specs for the app itself
+  //   maps/    specs for one map's own UI, kept beside the map they belong to,
+  //            so whoever implements a map writes them where they are working
+  testMatch: ["e2e/**/*_spec.ts", "maps/**/*_spec.ts"],
 
   // Retries stand in for the old deflake.sh, which re-ran the whole suite up to
   // three times and passed if any run passed. Retrying the failing test is

--- a/src/client/grid/inter_city_connection.tsx
+++ b/src/client/grid/inter_city_connection.tsx
@@ -144,8 +144,13 @@ function InterCityConnectionRender({
         r={size / 3}
         fill="black"
       />
+      {/* The data attributes are for the map specs: several maps build their own
+          rules on these connections, and the circle is otherwise an SVG shape
+          with a hashed class and nothing stable to select. */}
       <circle
         onClick={internalOnClick}
+        data-inter-city-connection={connection.id}
+        data-connection-owned={connection.owner != null ? "" : undefined}
         cx={connectionCenter.x}
         cy={connectionCenter.y}
         r={size / 3}

--- a/src/e2e/build_track_spec.ts
+++ b/src/e2e/build_track_spec.ts
@@ -1,27 +1,31 @@
-import { Page, expect, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import {
   createStartedGame,
   deleteGame,
   fetchGame,
-  loginAs,
   seedUsers,
   waitForVersionAfter,
 } from "./util/app";
+import {
+  buildFirstLegalTile,
+  buildsRemaining,
+  doneBuilding,
+  isShowing,
+  playUntil,
+} from "./util/play";
 
 /**
  * Building track: that clicking the grid reaches the engine.
  *
- * This is the spec the browser is actually needed for. Whether a build is legal,
+ * This is the spec a browser is actually needed for. Whether a build is legal,
  * what it costs, and what the board looks like afterwards are all engine
  * questions, covered in process and in far more depth by the recorded
- * playthroughs. What only a browser can show is that the hex is clickable, that
- * it offers the builds the engine says are available, and that choosing one sends
- * an action the server accepts.
+ * playthroughs. What only a browser shows is that the hex is clickable, that it
+ * offers the builds available, and that choosing one sends an action the server
+ * accepts.
  *
- * So nothing here names a tile type or a coordinate. The spec finds a hex that
- * offers builds, takes the first one offered, and checks the game moved on. That
- * keeps it from failing every time a map's terrain or tile rules are adjusted --
- * the kind of breakage that made the old suite not worth fixing.
+ * Nothing here names a tile type or a coordinate, so a reseeded board or retuned
+ * terrain does not break it.
  */
 
 const GAME_KEY = "jamaica";
@@ -47,10 +51,13 @@ test("builds a track tile from the grid", async ({ page }) => {
   });
   created.push(game.id);
 
-  // Play the opening until somebody is asked to build. Jamaica's order is turn
-  // order, then shares, then action selection, then building; each is a single
-  // click for a player with no ambitions.
-  const builder = await advanceToBuilding(page, users, game.id);
+  const builder = await playUntil(
+    page,
+    users,
+    game.id,
+    (page) => isShowing(doneBuilding(page)),
+    { label: "the building phase" },
+  );
 
   const before = await fetchGame(api, game.id);
   const remainingBefore = await buildsRemaining(page);
@@ -74,161 +81,3 @@ test("builds a track tile from the grid", async ({ page }) => {
   await expect(doneBuilding(page)).toBeVisible();
   expect(after.activePlayerId).toBe(builder.id);
 });
-
-/** The button shown only to the player who is being asked to build. */
-function doneBuilding(page: Page) {
-  return page.getByRole("button", { name: "Done Building" });
-}
-
-/** How many builds the page says the current player has left. */
-async function buildsRemaining(page: Page): Promise<number> {
-  const text = await page
-    .getByText(/You can build \d+ more track tile/)
-    .innerText();
-  const match = /You can build (\d+) more track tile/.exec(text);
-  if (match == null)
-    throw new Error(`could not read builds left from "${text}"`);
-  return Number(match[1]);
-}
-
-/**
- * Clicks through the opening until the active player is asked to build.
- *
- * Which player that is changes as the phases go by, so this logs in as whoever
- * the server says is active. Driving it by what is on screen, rather than by
- * reading the engine's phase, keeps the spec off the engine's internals.
- */
-async function advanceToBuilding(
-  page: Page,
-  users: Awaited<ReturnType<typeof seedUsers>>,
-  gameId: number,
-) {
-  // Bounded so a rule change that leaves the game waiting fails here, loudly,
-  // rather than hanging.
-  for (let step = 0; step < 12; step++) {
-    const game = await fetchGame(page.request, gameId);
-    const active = users.find((user) => user.id === game.activePlayerId);
-    if (active == null) {
-      throw new Error(
-        `game ${gameId} has no active player among the seeded ones`,
-      );
-    }
-
-    await loginAs(page, active, `/app/games/${gameId}`);
-    await waitForGamePage(page);
-
-    // Action selection has no pass: a player must take one of the special
-    // actions, so it is handled separately from the phases that can be waved
-    // through.
-    const selectable = page.locator("[data-special-action][data-selectable]");
-    if ((await selectable.count()) > 0) {
-      await selectable.first().click();
-      await waitForVersionAfter(page.request, gameId, game.version);
-      continue;
-    }
-
-    // Whichever of the opening's minimal choices is on offer, or the build button
-    // if the opening is over. Waited for as one locator: checking each in turn
-    // without waiting races the client's first render, which is a single-page app
-    // still fetching the game when the navigation commits.
-    const choice = page
-      .getByRole("button", { name: /^(Take Shares|Skip|Pass|Done Building)$/ })
-      .first();
-    await expect(choice).toBeVisible({ timeout: 30_000 });
-
-    if ((await choice.innerText()).trim() === "Done Building") return active;
-
-    await choice.click();
-    await waitForVersionAfter(page.request, gameId, game.version);
-  }
-  throw new Error("never reached the building phase");
-}
-
-/**
- * Waits for the client to have actually drawn the game.
- *
- * loginAs only waits for the navigation to commit, which for a single-page client
- * is well before there is anything on screen.
- */
-async function waitForGamePage(page: Page): Promise<void> {
-  await expect(page.locator("[data-hex-grid]")).toBeVisible({
-    timeout: 30_000,
-  });
-}
-
-/**
- * Builds the first tile the server accepts.
- *
- * Nothing here names a coordinate or a tile type. The dialog offers every tile
- * that fits the terrain, including ones the server then refuses -- new track has
- * to leave a city or extend existing track, and the client does not check that --
- * so the spec tries candidates and stops when the game actually moves on.
- *
- * That is slower than naming a known-good hex, but it survives a reseeded board
- * or a change to a map's terrain, which is the kind of breakage that made the old
- * suite not worth repairing.
- */
-async function buildFirstLegalTile(
-  page: Page,
-  gameId: number,
-  fromVersion: number,
-): Promise<void> {
-  const hexes = page.locator("[data-hex-grid] [data-coordinates]");
-  const count = await hexes.count();
-  expect(count, "the grid rendered no hexes").toBeGreaterThan(0);
-
-  const options = page.locator("[data-building-options]");
-  for (let hex = 0; hex < count; hex++) {
-    await hexes.nth(hex).click({ force: true });
-    if (!(await isShowing(options))) continue;
-
-    const tiles = options.locator("[data-tile-type][data-orientation]");
-    for (let tile = 0, tiles_ = await tiles.count(); tile < tiles_; tile++) {
-      // force, because a rejected build leaves a toast sitting over the dialog.
-      await tiles.nth(tile).click({ force: true });
-      if (await versionAdvanced(page, gameId, fromVersion)) return;
-      await dismissErrors(page);
-      if (!(await isShowing(options))) break;
-    }
-
-    await page.keyboard.press("Escape");
-  }
-  throw new Error(
-    `tried every one of the ${count} hexes and the server accepted no build`,
-  );
-}
-
-async function isShowing(locator: ReturnType<Page["locator"]>) {
-  return locator.isVisible().catch(() => false);
-}
-
-/** Whether the game moved on, i.e. the server took the action. Short by design. */
-async function versionAdvanced(
-  page: Page,
-  gameId: number,
-  fromVersion: number,
-): Promise<boolean> {
-  const deadline = Date.now() + 2_000;
-  do {
-    if ((await fetchGame(page.request, gameId)).version > fromVersion) {
-      return true;
-    }
-  } while (Date.now() < deadline);
-  return false;
-}
-
-/**
- * Clears rejection notices.
- *
- * A refused build raises a toast, and they stack up over the dialog until nothing
- * beneath them can be clicked -- which is how this spec first failed.
- */
-async function dismissErrors(page: Page): Promise<void> {
-  const closers = page.locator('.Toastify__toast button[aria-label="close"]');
-  for (let i = await closers.count(); i > 0; i--) {
-    await closers
-      .first()
-      .click({ force: true })
-      .catch(() => {});
-  }
-}

--- a/src/e2e/util/app.ts
+++ b/src/e2e/util/app.ts
@@ -11,9 +11,7 @@ import { GameApi, GameStatus } from "../../api/game";
  * imported into a spec silently writes nulls.
  */
 
-// Not exported: the specs only ever receive these from seedUsers, and an
-// exported type nothing imports is noise.
-interface SeededUser {
+export interface SeededUser {
   id: number;
   username: string;
 }

--- a/src/e2e/util/app.ts
+++ b/src/e2e/util/app.ts
@@ -138,6 +138,28 @@ async function post(
 }
 
 /**
+ * Submits one action as whoever this context is signed in as.
+ *
+ * For setting a position up. A spec that wants to test the UI of some mid-game
+ * moment should not have to click its way there through phases that have their own
+ * specs already -- but it does need the position to be one the engine really
+ * produces, which is why this goes through the ordinary action endpoint and not
+ * around it.
+ */
+export async function performAction(
+  request: APIRequestContext,
+  gameId: number,
+  actionName: string,
+  actionData: unknown,
+): Promise<void> {
+  await post(request, `/api/games/${gameId}/action`, {
+    actionName,
+    actionData,
+    confirmed: true,
+  });
+}
+
+/**
  * Creates a two-player game and starts it on a fixed seed.
  *
  * Built through the API rather than the UI on purpose: the create-game flow has

--- a/src/e2e/util/play.ts
+++ b/src/e2e/util/play.ts
@@ -1,5 +1,11 @@
 import { Locator, Page, expect } from "@playwright/test";
-import { fetchGame, loginAs, SeededUser, waitForVersionAfter } from "./app";
+import {
+  fetchGame,
+  loginAs,
+  performAction,
+  SeededUser,
+  waitForVersionAfter,
+} from "./app";
 
 /**
  * Driving a game through the browser.
@@ -24,7 +30,7 @@ async function waitForGamePage(page: Page): Promise<void> {
 }
 
 /** Signs in as whoever the server says is to move, and opens the game. */
-async function openAsActivePlayer(
+export async function openAsActivePlayer(
   page: Page,
   users: SeededUser[],
   gameId: number,
@@ -207,4 +213,40 @@ export async function buildFirstLegalTile(
   throw new Error(
     `tried every one of the ${count} hexes and the server accepted no build`,
   );
+}
+
+/**
+ * Applies a scripted list of actions, each as whoever is to move.
+ *
+ * How a map spec reaches a position deep enough to be interesting without
+ * clicking through phases that already have their own specs. The script is short
+ * on purpose -- it is found once, by searching seeds for a game that arrives
+ * somewhere useful in as few moves as possible -- and it runs through the real
+ * action endpoint, so the position is one the engine genuinely produces.
+ */
+export async function applyScript(
+  page: Page,
+  users: SeededUser[],
+  gameId: number,
+  script: Array<{ actionName: string; actionData: unknown }>,
+): Promise<void> {
+  for (const [index, action] of script.entries()) {
+    const before = await fetchGame(page.request, gameId);
+    const active = users.find((user) => user.id === before.activePlayerId);
+    if (active == null) {
+      throw new Error(
+        `nobody seeded is to move at script step ${index} (${action.actionName})`,
+      );
+    }
+    // Signs in rather than posting blind: the endpoint checks the caller is the
+    // active player, so a script that has drifted fails here with the step named.
+    await loginAs(page, active);
+    await performAction(
+      page.request,
+      gameId,
+      action.actionName,
+      action.actionData,
+    );
+    await waitForVersionAfter(page.request, gameId, before.version);
+  }
 }

--- a/src/e2e/util/play.ts
+++ b/src/e2e/util/play.ts
@@ -1,0 +1,210 @@
+import { Locator, Page, expect } from "@playwright/test";
+import { fetchGame, loginAs, SeededUser, waitForVersionAfter } from "./app";
+
+/**
+ * Driving a game through the browser.
+ *
+ * Shared by the general specs under src/e2e and by the per-map specs that live
+ * beside their map (src/maps/<map>/*_spec.ts). A map spec usually wants to reach
+ * some position its own rules produce, and getting there is the same clicking
+ * every time, so it belongs here rather than being copied per map.
+ *
+ * Everything is driven by what is on screen and by what the API reports, never by
+ * reading the engine's phase out of the serialized state. That is the point: these
+ * specs should keep working while the engine is refactored underneath them.
+ */
+
+/** Waits for the client to have actually drawn the game. */
+async function waitForGamePage(page: Page): Promise<void> {
+  // loginAs only waits for the navigation to commit, which for a single-page
+  // client is well before there is anything on screen.
+  await expect(page.locator("[data-hex-grid]")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/** Signs in as whoever the server says is to move, and opens the game. */
+async function openAsActivePlayer(
+  page: Page,
+  users: SeededUser[],
+  gameId: number,
+): Promise<SeededUser> {
+  const game = await fetchGame(page.request, gameId);
+  const active = users.find((user) => user.id === game.activePlayerId);
+  if (active == null) {
+    throw new Error(
+      `game ${gameId} has no active player among the seeded ones`,
+    );
+  }
+  await loginAs(page, active, `/app/games/${gameId}`);
+  await waitForGamePage(page);
+  return active;
+}
+
+/** The button offered only to the player being asked to build. */
+export function doneBuilding(page: Page): Locator {
+  return page.getByRole("button", { name: "Done Building" });
+}
+
+/** How many builds the page says the player still has. */
+export async function buildsRemaining(page: Page): Promise<number> {
+  const text = await page
+    .getByText(/You can build \d+ more track tile/)
+    .innerText();
+  const match = /You can build (\d+) more track tile/.exec(text);
+  if (match == null) {
+    throw new Error(`could not read builds left from "${text}"`);
+  }
+  return Number(match[1]);
+}
+
+/**
+ * The minimal choices that move a game's opening along.
+ *
+ * Taking no shares and passing on turn order keeps things moving without needing
+ * to understand the position. Action selection is absent on purpose: it has no
+ * pass, so it is handled separately.
+ */
+const OPENING_CHOICES = /^(Take Shares|Skip|Pass)$/;
+
+/**
+ * Plays the opening until `stop` says the game has arrived somewhere interesting.
+ *
+ * Which player is to move changes as the phases go by, so this signs in as
+ * whoever the server reports active. Returns that player.
+ *
+ * `stop` is given the page after it has rendered; a map spec passes whatever marks
+ * its own position -- the build button, its own modal, a phase heading.
+ */
+export async function playUntil(
+  page: Page,
+  users: SeededUser[],
+  gameId: number,
+  stop: (page: Page) => Promise<boolean>,
+  options: { maxSteps?: number; label?: string } = {},
+): Promise<SeededUser> {
+  const maxSteps = options.maxSteps ?? 24;
+  // Bounded so a rule change that leaves the game waiting fails loudly here
+  // instead of hanging until the whole spec times out.
+  for (let step = 0; step < maxSteps; step++) {
+    const before = await fetchGame(page.request, gameId);
+    const active = await openAsActivePlayer(page, users, gameId);
+
+    if (await stop(page)) return active;
+
+    if (!(await takeAnyTurn(page))) {
+      throw new Error(
+        `nothing to click at step ${step} while waiting for ` +
+          `${options.label ?? "the target position"}`,
+      );
+    }
+    await waitForVersionAfter(page.request, gameId, before.version);
+  }
+  throw new Error(
+    `never reached ${options.label ?? "the target position"} in ${maxSteps} steps`,
+  );
+}
+
+/**
+ * Makes the least interesting legal move available, and says whether it managed to.
+ *
+ * Action selection is tried first because it is the one opening phase a player
+ * cannot decline.
+ */
+async function takeAnyTurn(page: Page): Promise<boolean> {
+  const selectable = page.locator("[data-special-action][data-selectable]");
+  if ((await selectable.count()) > 0) {
+    await selectable.first().click();
+    return true;
+  }
+
+  const choice = page.getByRole("button", { name: OPENING_CHOICES }).first();
+  // Waited for as one locator: probing each label without waiting races the
+  // client's first render.
+  if (await isShowing(choice)) {
+    await choice.click();
+    return true;
+  }
+
+  const done = doneBuilding(page);
+  if (await isShowing(done)) {
+    await done.click();
+    return true;
+  }
+  return false;
+}
+
+/** Whether a locator is on screen right now, without waiting for it. */
+export async function isShowing(locator: Locator): Promise<boolean> {
+  return locator.isVisible().catch(() => false);
+}
+
+/** Whether the game moved on, i.e. the server took an action. Short by design. */
+export async function versionAdvanced(
+  page: Page,
+  gameId: number,
+  fromVersion: number,
+  withinMs = 2_000,
+): Promise<boolean> {
+  const deadline = Date.now() + withinMs;
+  do {
+    if ((await fetchGame(page.request, gameId)).version > fromVersion) {
+      return true;
+    }
+  } while (Date.now() < deadline);
+  return false;
+}
+
+/**
+ * Clears rejection notices.
+ *
+ * A refused action raises a toast, and they stack up over whatever is beneath
+ * until nothing there can be clicked.
+ */
+async function dismissErrors(page: Page): Promise<void> {
+  const closers = page.locator('.Toastify__toast button[aria-label="close"]');
+  for (let i = await closers.count(); i > 0; i--) {
+    await closers
+      .first()
+      .click({ force: true })
+      .catch(() => {});
+  }
+}
+
+/**
+ * Builds the first tile the server accepts, anywhere on the board.
+ *
+ * The dialog offers every tile that fits the terrain, including ones the server
+ * then refuses -- new track has to leave a city or extend existing track, and the
+ * client does not check that -- so this tries candidates and stops when the game
+ * moves on.
+ */
+export async function buildFirstLegalTile(
+  page: Page,
+  gameId: number,
+  fromVersion: number,
+): Promise<void> {
+  const hexes = page.locator("[data-hex-grid] [data-coordinates]");
+  const count = await hexes.count();
+  expect(count, "the grid rendered no hexes").toBeGreaterThan(0);
+
+  const options = page.locator("[data-building-options]");
+  for (let hex = 0; hex < count; hex++) {
+    await hexes.nth(hex).click({ force: true });
+    if (!(await isShowing(options))) continue;
+
+    const tiles = options.locator("[data-tile-type][data-orientation]");
+    for (let tile = 0, total = await tiles.count(); tile < total; tile++) {
+      // force, because a rejected build leaves a toast over the dialog.
+      await tiles.nth(tile).click({ force: true });
+      if (await versionAdvanced(page, gameId, fromVersion)) return;
+      await dismissErrors(page);
+      if (!(await isShowing(options))) break;
+    }
+
+    await page.keyboard.press("Escape");
+  }
+  throw new Error(
+    `tried every one of the ${count} hexes and the server accepted no build`,
+  );
+}

--- a/src/maps/denmark/denmark_spec.ts
+++ b/src/maps/denmark/denmark_spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "@playwright/test";
+import {
+  createStartedGame,
+  deleteGame,
+  fetchGame,
+  seedUsers,
+  waitForVersionAfter,
+} from "../../e2e/util/app";
+import {
+  doneBuilding,
+  isShowing,
+  playUntil,
+  versionAdvanced,
+} from "../../e2e/util/play";
+
+/**
+ * Denmark's own UI.
+ *
+ * Map specs live beside the map they cover, so whoever implements a map writes
+ * them where they are already working. Playwright picks up maps/<map>/*_spec.ts
+ * as well as the general specs under e2e/; the shared driving helpers are in
+ * e2e/util/play.
+ *
+ * Scope is the same as for the general specs: wiring only. Whether a ferry may be
+ * claimed, and what it costs, are engine questions, and cheaper to answer in
+ * process. What only a browser shows is that the connection is on the board, that
+ * it can be clicked, and that clicking it sends an action the server accepts.
+ *
+ * Denmark is a good first case because its ferry connections between cities are
+ * drawn and clicked in a way no base-game map uses.
+ *
+ * Deliberately not covered here: that Denmark deals everyone negative starting
+ * income. It is true, and it caught out an engine invariant once, but it is a fact
+ * about the engine rather than about the UI, and asserting it through the player
+ * table would mean encoding which of that table's responsive variants is on screen.
+ */
+
+const GAME_KEY = "denmark";
+// Fixed, so the board and the starting position are the same every run.
+const SEED = "e2e-denmark";
+// Denmark seats three at the least.
+const PLAYERS = 3;
+
+let created: number[] = [];
+
+test.afterEach(async ({ request }) => {
+  for (const gameId of created) await deleteGame(request, gameId);
+  created = [];
+});
+
+test("claims a ferry connection between two cities", async ({ page }) => {
+  const api = page.request;
+  const users = await seedUsers(api, PLAYERS);
+  const name = `e2e denmark ${Date.now()}`.slice(0, 32);
+
+  const game = await createStartedGame(page, users, {
+    gameKey: GAME_KEY,
+    name,
+    seed: SEED,
+  });
+  created.push(game.id);
+
+  const builder = await playUntil(
+    page,
+    users,
+    game.id,
+    (page) => isShowing(doneBuilding(page)),
+    { label: "Denmark's building phase" },
+  );
+
+  // Denmark's ferries are drawn as connections between cities rather than as
+  // track on a hex, so they are their own click target.
+  const unclaimed = page.locator(
+    "[data-inter-city-connection]:not([data-connection-owned])",
+  );
+  await expect(
+    unclaimed.first(),
+    "Denmark should offer unclaimed ferry connections",
+  ).toBeVisible({ timeout: 30_000 });
+
+  const before = await fetchGame(api, game.id);
+  const claimed = await claimAffordableConnection(
+    page,
+    game.id,
+    before.version,
+  );
+
+  const after = await waitForVersionAfter(api, game.id, before.version);
+  expect(after.version).toBeGreaterThan(before.version);
+  // The board now shows it owned, which is the render half of the round trip.
+  await expect(
+    page.locator(
+      `[data-inter-city-connection="${claimed}"][data-connection-owned]`,
+    ),
+  ).toBeVisible({ timeout: 30_000 });
+  // Still that player's build phase: claiming a connection is a build, not a pass.
+  expect(after.activePlayerId).toBe(builder.id);
+});
+
+/**
+ * Claims the first ferry the server accepts.
+ *
+ * Ferries differ in cost, and a player who cannot afford one gets an error rather
+ * than a refusal up front, so this tries them in turn rather than assuming the
+ * cheapest is first on the board.
+ */
+async function claimAffordableConnection(
+  page: import("@playwright/test").Page,
+  gameId: number,
+  fromVersion: number,
+): Promise<string> {
+  const unclaimed = page.locator(
+    "[data-inter-city-connection]:not([data-connection-owned])",
+  );
+  const total = await unclaimed.count();
+  expect(total, "no unclaimed ferry connections on the board").toBeGreaterThan(
+    0,
+  );
+
+  for (let index = 0; index < total; index++) {
+    const connection = unclaimed.nth(index);
+    const id = await connection.getAttribute("data-inter-city-connection");
+    if (id == null) continue;
+    // force: an SVG circle, and a previous rejection may have left a toast over it.
+    await connection.click({ force: true });
+    if (await versionAdvanced(page, gameId, fromVersion)) return id;
+  }
+  throw new Error(
+    `clicked all ${total} unclaimed connections and the server accepted none`,
+  );
+}

--- a/src/maps/denmark/denmark_spec.ts
+++ b/src/maps/denmark/denmark_spec.ts
@@ -7,8 +7,10 @@ import {
   waitForVersionAfter,
 } from "../../e2e/util/app";
 import {
+  applyScript,
   doneBuilding,
   isShowing,
+  openAsActivePlayer,
   playUntil,
   versionAdvanced,
 } from "../../e2e/util/play";
@@ -129,3 +131,102 @@ async function claimAffordableConnection(
     `clicked all ${total} unclaimed connections and the server accepted none`,
   );
 }
+
+/**
+ * The position that puts instant production on screen.
+ *
+ * Instant production fires once a delivery completes, so a spec cannot simply
+ * open a fresh game and look at it. Rather than click a whole round out, this
+ * fast-forwards with the shortest script that gets there: nobody takes shares,
+ * nobody bids, each player takes whatever action is going, the first builder
+ * claims one ferry and everyone stops building. Then one delivery over that
+ * ferry, and the modal is waiting.
+ *
+ * The seed is not arbitrary. Whether a delivery exists at all depends on which
+ * cubes the board was dealt, so seeds were searched until one turned up where the
+ * ferry's two cities allow a delivery in round one. That is what keeps the script
+ * to thirteen actions.
+ *
+ * If this script stops applying, the game no longer reaches this position the same
+ * way -- a rules change, or a different colour assignment. The failure names the
+ * step, and the search that produced it can be run again.
+ */
+const INSTANT_PRODUCTION_SEED = "denmark-ip-0";
+const FERRY_ID = "5";
+const OPENING: Array<{ actionName: string; actionData: unknown }> = [
+  { actionName: "takeShares", actionData: { numShares: 0 } },
+  { actionName: "takeShares", actionData: { numShares: 0 } },
+  { actionName: "takeShares", actionData: { numShares: 0 } },
+  { actionName: "pass", actionData: {} },
+  { actionName: "pass", actionData: {} },
+  { actionName: "select", actionData: { action: 1 } },
+  { actionName: "select", actionData: { action: 2 } },
+  { actionName: "select", actionData: { action: 3 } },
+  // Frederikshaven to Copenhagen.
+  { actionName: "connect-cities", actionData: { id: FERRY_ID } },
+  { actionName: "done", actionData: {} },
+  { actionName: "done", actionData: {} },
+  { actionName: "done", actionData: {} },
+  // The delivery that triggers instant production. The owner is a player colour,
+  // which the fixed seed pins down.
+  {
+    actionName: "move",
+    actionData: {
+      startingCity: { q: 9, r: 5 },
+      good: 4,
+      path: [{ owner: 4, endingStop: { q: 1, r: 14 } }],
+    },
+  },
+];
+
+test("offers a city for instant production after a delivery", async ({
+  page,
+}) => {
+  const api = page.request;
+  const users = await seedUsers(api, PLAYERS);
+  const name = `e2e dk ip ${Date.now()}`.slice(0, 32);
+
+  const game = await createStartedGame(page, users, {
+    gameKey: GAME_KEY,
+    name,
+    seed: INSTANT_PRODUCTION_SEED,
+  });
+  created.push(game.id);
+
+  await applyScript(page, users, game.id, OPENING);
+
+  const pending = await openAsActivePlayer(page, users, game.id);
+  await expect(
+    page.locator("[data-instant-production]"),
+    "a delivery should leave instant production waiting",
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Not scoped to the container above: the dialog is a Semantic UI Modal, which
+  // renders through a portal on the body rather than inside its own subtree.
+  const cities = page.locator("[data-city-option]");
+  // The choice is between the two ends of the delivery, and only those.
+  await expect(cities).toHaveCount(2, { timeout: 30_000 });
+
+  // Confirming is refused until one is picked, which is the modal's own rule
+  // rather than the engine's.
+  const confirm = page.getByRole("button", { name: "Select City" });
+  await expect(confirm).toBeDisabled();
+
+  const chosen = await cities.first().getAttribute("data-city-option");
+  await cities.first().click();
+  await expect(confirm).toBeEnabled();
+
+  const before = await fetchGame(api, game.id);
+  await confirm.click();
+
+  // The engine took it: the game moved on and the modal is done with.
+  const after = await waitForVersionAfter(api, game.id, before.version);
+  expect(after.version).toBeGreaterThan(before.version);
+  // The choice is spent, so the dialog has nothing left to offer.
+  await expect(cities).toHaveCount(0, { timeout: 30_000 });
+
+  expect(chosen, "a city option should name its coordinates").toMatch(
+    /^-?\d+\|-?\d+$/,
+  );
+  expect(pending.id).toBeTruthy();
+});

--- a/src/modules/instant_production/instant_production_view.tsx
+++ b/src/modules/instant_production/instant_production_view.tsx
@@ -72,6 +72,7 @@ export function InstantProductionMoveGoodsActionSummary() {
                   key={idx}
                   className={`${styles.cityOption} ${selectedCity && option.coordinates.equals(selectedCity) ? styles.selected : ""}`}
                   onClick={() => setSelectedCity(option.coordinates)}
+                  data-city-option={option.coordinates.serialize()}
                 >
                   <div>{option.name()}</div>
                   <CityInfo city={option} />
@@ -112,6 +113,7 @@ export function InstantProductionMoveGoodsActionSummary() {
                   key={idx}
                   className={`${styles.cityOption} ${selectedCity && option.coordinates.equals(selectedCity) ? styles.selected : ""}`}
                   onClick={() => setSelectedCity(option.coordinates)}
+                  data-city-option={option.coordinates.serialize()}
                 >
                   <div>{option.name()}</div>
                   <CityInfo city={option} />
@@ -128,8 +130,11 @@ export function InstantProductionMoveGoodsActionSummary() {
       );
     }
 
+    // data-instant-production marks the modal for the map specs that cover it;
+    // the two city cards carry data-city-option. Both are otherwise divs with
+    // hashed CSS module classes and nothing stable to select.
     return (
-      <div>
+      <div data-instant-production>
         <Modal closeIcon open={open} onClose={() => setOpen(false)}>
           <Header>Perform Instant Production</Header>
           <ModalContent>{content}</ModalContent>


### PR DESCRIPTION
Maps add UI the base game has no equivalent of, and until now there was nowhere to
test it. Builds on the Playwright suite from #344.

## The arrangement

Playwright now picks up `maps/<map>/*_spec.ts` alongside the general specs under
`e2e/`, so a map's specs sit beside the map — where whoever implements it is
already working. Two globs rather than one over `src/`, because the prober uses
the same `_spec.ts` suffix and drives production from its own config.

The clicking needed to *reach* a position moved out of `build_track_spec` into
`e2e/util/play`: sign in as whoever is to move, wave the opening through, stop
when the map's own UI appears. A map spec supplies only its stopping condition and
otherwise says nothing about how the game got there.

## Denmark

Two specs, both wiring-only. Whether a ferry may be claimed, what it costs, and
what a delivery earns are engine questions, answered in process and far more
cheaply.

- **Claiming a ferry.** Denmark's connections between cities are drawn and clicked
  in a way no base-game map uses. The spec claims one and checks the server took
  it and the board redrew it as owned.
- **Instant production.** Its modal only appears once a delivery completes, so the
  spec fast-forwards with the shortest script that gets there — thirteen actions:
  nobody takes shares, nobody bids, each player takes whatever action is going,
  the first builder claims one ferry, everyone stops building, one good crosses
  it. Then it asserts the modal and only the modal: that it offers the two ends of
  the delivery and nothing else, that it refuses to confirm until one is picked,
  and that picking one sends an action the server accepts.

The script runs through the ordinary action endpoint rather than around it, so the
position is one the engine genuinely produces. If it ever stops applying, the
failure names the step.

## Notes for review

- **The seed is not arbitrary.** Whether any delivery exists in round one depends
  on which cubes the board was dealt, so seeds were searched — driving the engine
  directly and using it as the oracle for legality — until one turned up where a
  single ferry's two cities allow a delivery straight away. That search is what
  keeps the script to thirteen actions; without it the spec would have to build
  track toward a good and would depend on the board far more deeply.
- **Off-map ferries are not deliverable this way.** The first four of Denmark's
  connections lead to Europe and Göteborg, and a good sitting in Hirtshals fails
  with `no routes found between Hirtshals and Europe`. Worth knowing before
  assuming any connection will do; it is why the search sweeps all twenty-six.
- **Three elements needed naming.** The ferry circles and the two city cards in
  the instant-production modal were SVG shapes and divs with hashed CSS module
  classes — nothing stable to select. They now carry `data-` attributes like the
  rest of the client already does.
- **Semantic UI `Modal` renders through a portal on the body.** The city cards are
  not inside the element that renders them, so a locator scoped to the
  component's own subtree finds nothing even though the modal is plainly visible.
  Likely to catch out the next person testing a dialog here.
- **Deliberately not asserted:** that Denmark deals everyone negative starting
  income. It does, and it caught out an engine invariant once, but it is a fact
  about the engine rather than the UI, and reading it off the player table meant
  depending on which responsive variant of that table was on screen.
- Both specs were checked for teeth — the ferry one by watching a wrong map
  assertion fail, the instant-production one by dropping the delivery from the
  script, after which the modal never appears and the assertion says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)