### PR TITLE
Split the drawn-good selection out of GoodsTable

### DIFF
--- a/src/client/game/action_summary.tsx
+++ b/src/client/game/action_summary.tsx
@@ -46,6 +46,7 @@ import {
 import { Build } from "./build_action_summary";
 import { ManualGoodsGrowth } from "./india-steam-brothers/goods_growth";
 import { MoveGoods } from "./move_goods_action_summary";
+import { ProductionSummary } from "./production_summary";
 
 const PASS_ACTION = "Pass" as const;
 type PassActionString = typeof PASS_ACTION;
@@ -87,6 +88,8 @@ export function ActionSummary() {
       return <Deurbanization />;
     case Phase.MANUAL_GOODS_GROWTH:
       return <ManualGoodsGrowth />;
+    case Phase.GOODS_GROWTH:
+      return <ProductionSummary />;
     case Phase.DISCO_INFERNO_PRODUCTION:
       return <DiscoProduction />;
     case Phase.EARTH_TO_HEAVEN:
@@ -97,7 +100,6 @@ export function ActionSummary() {
       return <GovernmentBuild />;
     case Phase.STALINIST_LOCOMOTIVE:
     case Phase.ROLE_SELECTION:
-    case Phase.GOODS_GROWTH:
     case Phase.INCOME:
     case Phase.EXPENSES:
     case Phase.INCOME_REDUCTION:

--- a/src/client/game/active_game.tsx
+++ b/src/client/game/active_game.tsx
@@ -64,7 +64,6 @@ function InternalActiveGame() {
         <SwitchToActive />
         <SwitchToUndo />
         {!undoOnly && <ActionSummary />}
-        {!undoOnly && canEmitProduction && <GoodsTable />}
         {!undoOnly && <BiddingInfo />}
         {!undoOnly && canEmitSelectAction && <SpecialActionTable />}
         <AutoActionForm />

--- a/src/client/game/goods_table.tsx
+++ b/src/client/game/goods_table.tsx
@@ -1,28 +1,20 @@
-import { useCallback, useMemo } from "react";
-import { Button, Icon } from "semantic-ui-react";
+import { useMemo } from "react";
 import { PHASE } from "../../engine/game/phase";
 import { GameStarter } from "../../engine/game/starter";
 import { AVAILABLE_CITIES } from "../../engine/game/state";
-import { PassAction } from "../../engine/goods_growth/pass";
-import { ProductionAction } from "../../engine/goods_growth/production";
-import { GOODS_GROWTH_STATE } from "../../engine/goods_growth/state";
 import { CityGroup } from "../../engine/state/city_group";
-import { Good, goodToString } from "../../engine/state/good";
+import { Good } from "../../engine/state/good";
 import { Phase } from "../../engine/state/phase";
 import { OnRoll } from "../../engine/state/roll";
 import { SwedenRecyclingMapSettings } from "../../maps/sweden/settings";
 import { iterate } from "../../utils/functions";
 import { ImmutableMap } from "../../utils/immutable";
-import { assert } from "../../utils/validate";
-import { Username } from "../components/username";
 import { goodStyle } from "../grid/good";
-import { useAction, useEmptyAction } from "../services/action";
-import { useGame, useGameVersionState } from "../services/game";
+import { useGame } from "../services/game";
 import {
   useGrid,
   useInjected,
   useInjectedState,
-  usePhaseState,
 } from "../utils/injection_context";
 import * as styles from "./goods_table.module.css";
 
@@ -36,11 +28,30 @@ function getMaxGoods(
   return Math.max(...goodArrays.map((goods) => goods.length));
 }
 
-export function GoodsTable() {
+/** One slot of the goods display. */
+export interface GoodsSlot {
+  urbanized: boolean;
+  cityGroup: CityGroup;
+  onRoll: OnRoll;
+  row: number;
+}
+
+interface GoodsTableProps {
+  /** Called when a clickable slot is clicked. Absent means display only. */
+  onClickSlot?(slot: GoodsSlot): void;
+  /**
+   * Which slots respond to a click, given what is currently in them. Absent
+   * means none of them do. Placing a drawn good targets empty slots; an action
+   * that takes goods off the display targets full ones.
+   */
+  isSlotClickable?(slot: GoodsSlot, good: Good | undefined): boolean;
+}
+
+export function GoodsTable({
+  onClickSlot,
+  isSlotClickable,
+}: GoodsTableProps = {}) {
   const gameKey = useGame().gameKey;
-  const [manuallySelectedGood, setSelectedGood] = useGameVersionState<
-    Good | undefined
-  >(undefined);
   const grid = useGrid();
   const phase = useInjectedState(PHASE);
   const starter = useInjected(GameStarter);
@@ -81,30 +92,6 @@ export function GoodsTable() {
     [cities],
   );
 
-  const { emit, canEmit } = useAction(ProductionAction);
-  const productionState = usePhaseState(Phase.GOODS_GROWTH, GOODS_GROWTH_STATE);
-
-  const good = manuallySelectedGood ?? productionState?.goods[0];
-
-  const onClick = useCallback(
-    (urbanized: boolean, cityGroup: CityGroup, onRoll: OnRoll, row: number) => {
-      if (!canEmit) return;
-      assert(good != null);
-      emit({ urbanized, onRoll, cityGroup, good, row });
-    },
-    [canEmit, emit, good],
-  );
-
-  const toggleSelectedGood = useCallback(() => {
-    assert(productionState != null);
-    assert(good != null);
-    setSelectedGood(
-      productionState.goods[
-        (productionState.goods.indexOf(good) + 1) % productionState.goods.length
-      ],
-    );
-  }, [good, productionState]);
-
   const hasUrbanizedCities =
     cities.urbanizedCities.get(CityGroup.WHITE)!.length +
       cities.urbanizedCities.get(CityGroup.BLACK)!.length >
@@ -120,10 +107,18 @@ export function GoodsTable() {
     return <></>;
   }
 
+  function slotProps(slot: GoodsSlot, good: Good | undefined) {
+    const clickable = isSlotClickable?.(slot, good) ?? false;
+    return {
+      good,
+      clickable,
+      onClick: clickable ? () => onClickSlot?.(slot) : undefined,
+    };
+  }
+
   return (
     <div>
       <h2>Goods Growth Table</h2>
-      <PlaceGood good={good} toggleSelectedGood={toggleSelectedGood} />
       <div className={styles.goodsContainer}>
         <div className={styles.row}>
           <div>White</div>
@@ -143,42 +138,33 @@ export function GoodsTable() {
                 key={i}
               >
                 <div>{onRoll}</div>
-                {iterate(maxRegularGoods, (goodIndex) => (
-                  <GoodBlock
-                    key={goodIndex}
-                    good={city?.[maxRegularGoods - 1 - goodIndex] ?? undefined}
-                    canSelect={canEmit}
-                    onClick={() =>
-                      onClick(
-                        false,
-                        cityGroup,
-                        onRoll,
-                        maxRegularGoods - 1 - goodIndex,
-                      )
-                    }
-                  />
-                ))}
-                {hasUrbanizedCities && <div>{urbanizedCity && letter}</div>}
-                {hasUrbanizedCities &&
-                  iterate(maxUrbanizedGoods, (goodIndex) => (
+                {iterate(maxRegularGoods, (goodIndex) => {
+                  const row = maxRegularGoods - 1 - goodIndex;
+                  return (
                     <GoodBlock
                       key={goodIndex}
-                      good={
-                        urbanizedCity?.[maxUrbanizedGoods - 1 - goodIndex] ??
-                        undefined
-                      }
-                      canSelect={canEmit}
-                      emptySpace={urbanizedCity == null}
-                      onClick={() =>
-                        onClick(
-                          true,
-                          cityGroup,
-                          onRoll,
-                          maxUrbanizedGoods - 1 - goodIndex,
-                        )
-                      }
+                      {...slotProps(
+                        { urbanized: false, cityGroup, onRoll, row },
+                        city?.[row] ?? undefined,
+                      )}
                     />
-                  ))}
+                  );
+                })}
+                {hasUrbanizedCities && <div>{urbanizedCity && letter}</div>}
+                {hasUrbanizedCities &&
+                  iterate(maxUrbanizedGoods, (goodIndex) => {
+                    const row = maxUrbanizedGoods - 1 - goodIndex;
+                    return (
+                      <GoodBlock
+                        key={goodIndex}
+                        emptySpace={urbanizedCity == null}
+                        {...slotProps(
+                          { urbanized: true, cityGroup, onRoll, row },
+                          urbanizedCity?.[row] ?? undefined,
+                        )}
+                      />
+                    );
+                  })}
               </div>
             );
           })}
@@ -188,53 +174,10 @@ export function GoodsTable() {
   );
 }
 
-function PlaceGood({
-  good,
-  toggleSelectedGood,
-}: {
-  good?: Good;
-  toggleSelectedGood(): void;
-}) {
-  const { canEmit, canEmitUserId } = useAction(ProductionAction);
-  const { emit: emitPass } = useEmptyAction(PassAction);
-  const state = usePhaseState(Phase.GOODS_GROWTH, GOODS_GROWTH_STATE);
-  if (canEmitUserId == null) {
-    return <></>;
-  }
-
-  return (
-    <div>
-      <p>
-        {canEmit ? "You" : <Username userId={canEmitUserId} />} drew{" "}
-        {state!.goods.map(goodToString).join(", ")}
-      </p>
-      {canEmit && (
-        <div>
-          <p>Select where to place {goodToString(good!)}.</p>
-          {state!.goods.length > 1 && (
-            <Button
-              icon
-              labelPosition="left"
-              color="teal"
-              onClick={toggleSelectedGood}
-            >
-              <Icon name="arrows alternate horizontal" />
-              Switch selected good
-            </Button>
-          )}
-          <Button negative onClick={emitPass}>
-            Pass
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}
-
 interface GoodBlockProps {
   onClick?: () => void;
   good?: Good;
-  canSelect?: boolean;
+  clickable?: boolean;
   emptySpace?: boolean;
   className?: string;
 }
@@ -242,20 +185,21 @@ interface GoodBlockProps {
 export function GoodBlock({
   onClick,
   good,
-  canSelect,
+  clickable,
   emptySpace,
   className,
 }: GoodBlockProps) {
+  const showAsClickable = clickable && !emptySpace;
   const classNames = [
     styles.goodPlace,
     !emptySpace ? styles.good : "",
     good != null ? goodStyle(good) : styles.empty,
-    canSelect && !emptySpace && good == null ? styles.clickableGood : "",
+    showAsClickable ? styles.clickableGood : "",
     className ?? "",
   ];
   return (
     <div
-      onClick={canSelect ? onClick : undefined}
+      onClick={showAsClickable ? onClick : undefined}
       className={classNames.join(" ")}
     />
   );

--- a/src/client/game/production_summary.tsx
+++ b/src/client/game/production_summary.tsx
@@ -1,0 +1,90 @@
+import { useCallback } from "react";
+import { Button, Icon } from "semantic-ui-react";
+import { PassAction } from "../../engine/goods_growth/pass";
+import { ProductionAction } from "../../engine/goods_growth/production";
+import { GOODS_GROWTH_STATE } from "../../engine/goods_growth/state";
+import { Good, goodToString } from "../../engine/state/good";
+import { Phase } from "../../engine/state/phase";
+import { assert } from "../../utils/validate";
+import { Username } from "../components/username";
+import { useAction, useEmptyAction } from "../services/action";
+import { useGameVersionState } from "../services/game";
+import { usePhaseState } from "../utils/injection_context";
+import { GoodsSlot, GoodsTable } from "./goods_table";
+
+/**
+ * The base game's production action: place the goods you drew into empty slots of
+ * the goods display. Owns the drawn-good selection and drives the goods table
+ * with it, so that a map replacing this action can reuse the table on its own
+ * terms.
+ */
+export function ProductionSummary() {
+  const { emit, canEmit, canEmitUserId } = useAction(ProductionAction);
+  const state = usePhaseState(Phase.GOODS_GROWTH, GOODS_GROWTH_STATE);
+  const [manuallySelectedGood, setSelectedGood] = useGameVersionState<
+    Good | undefined
+  >(undefined);
+
+  const good = manuallySelectedGood ?? state?.goods[0];
+
+  const onClickSlot = useCallback(
+    ({ urbanized, cityGroup, onRoll, row }: GoodsSlot) => {
+      if (!canEmit) return;
+      assert(good != null);
+      emit({ urbanized, onRoll, cityGroup, good, row });
+    },
+    [canEmit, emit, good],
+  );
+
+  const toggleSelectedGood = useCallback(() => {
+    assert(state != null);
+    assert(good != null);
+    setSelectedGood(
+      state.goods[(state.goods.indexOf(good) + 1) % state.goods.length],
+    );
+  }, [good, state]);
+
+  if (canEmitUserId == null) {
+    return <></>;
+  }
+
+  return (
+    <div>
+      <p>
+        {canEmit ? "You" : <Username userId={canEmitUserId} />} drew{" "}
+        {state!.goods.map(goodToString).join(", ")}
+      </p>
+      {canEmit && (
+        <div>
+          <p>Select where to place {goodToString(good!)}.</p>
+          {state!.goods.length > 1 && (
+            <Button
+              icon
+              labelPosition="left"
+              color="teal"
+              onClick={toggleSelectedGood}
+            >
+              <Icon name="arrows alternate horizontal" />
+              Switch selected good
+            </Button>
+          )}
+          <PassProduction />
+        </div>
+      )}
+      <GoodsTable
+        onClickSlot={onClickSlot}
+        // A drawn good can only go into an empty slot.
+        isSlotClickable={(_, slotGood) => canEmit && slotGood == null}
+      />
+    </div>
+  );
+}
+
+function PassProduction() {
+  const { emit } = useEmptyAction(PassAction);
+  return (
+    <Button negative onClick={emit}>
+      Pass
+    </Button>
+  );
+}

--- a/src/maps/minas-geraes/redraw_production.tsx
+++ b/src/maps/minas-geraes/redraw_production.tsx
@@ -1,8 +1,23 @@
 import { useEmptyAction } from "../../client/services/action";
 import { Button, Icon } from "semantic-ui-react";
+import { ProductionSummary } from "../../client/game/production_summary";
 import { RedrawProductionAction } from "./production";
 
+/**
+ * Minas Geraes keeps the base production action, so it needs the base production
+ * summary as well as its own redraw button. Taking over the goods growth action
+ * summary would otherwise replace it.
+ */
 export function RedrawProduction() {
+  return (
+    <>
+      <ProductionSummary />
+      <RedrawButton />
+    </>
+  );
+}
+
+function RedrawButton() {
   const { emit, canEmit } = useEmptyAction(RedrawProductionAction);
 
   if (!canEmit) {


### PR DESCRIPTION
`GoodsTable` did two jobs. It rendered the goods display, and it ran the base game's production action: holding the drawn-good selection, showing "you drew X" and "select where to place X", and offering the switch-good and pass buttons.

The second job was welded to the first, so a map whose production action *reads* the display rather than filling it could not reuse the table — it would inherit a prompt about placing a good it never drew, and a Pass button for an action its phase does not install.

## What changed

The production half moves to a new `ProductionSummary`, which `ActionSummary` renders for `Phase.GOODS_GROWTH`. That is the same slot the table used to occupy: `active_game` rendered it just below `ActionSummary` whenever someone could produce, so its top copy goes away and the display-only copy further down is unchanged.

What is left is presentational, and takes the interaction as two optional props:

```ts
onClickSlot?(slot: GoodsSlot): void
isSlotClickable?(slot: GoodsSlot, good: Good | undefined): boolean
```

Placing a drawn good asks for empty slots; an action that takes goods off the display asks for full ones. Neither rule belongs in the table.

`GoodBlock`'s `canSelect` prop becomes a plain `clickable`, dropping its hardcoded "only when the slot is empty". Its click handler is now gated on the same value, which it was not before: clicking a full slot used to emit an action the server rejected with `chosen onroll row is full`, so styling and behaviour now agree.

## Map compatibility

One map needed a change. Minas Geraes takes over the goods growth action summary for its redraw button *while still using the base production action*, which it could only do while the two lived in different components; its summary now composes `ProductionSummary` in.

Every other map that overrides that summary — Central New England, Mexico, Poland — installs its own production action instead of the base one, so none of them were relying on the table for input. Sweden removes `Action.PRODUCTION` altogether.

## Testing

- `npm test` — 21 files, 1292 tests
- `npm run test-playthroughs` — 54 files, 108 tests, which is what exercises Minas Geraes and Jamaica production through real recorded games
- `npm run lint` (eslint + knip) and `prettier --check src/` clean

## Why

Groundwork for an O'ahu map whose Production action is inverted — the player picks a display column and the whole column empties into its city — but the split stands on its own and that map is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
