### PR TITLE
Stop rebuilding the grid on every read

### DIFF
--- a/src/engine/game/state.ts
+++ b/src/engine/game/state.ts
@@ -19,7 +19,7 @@ import {
   PlayerColorZod,
   PlayerData,
 } from "../state/player";
-import { MutableSpaceData } from "../state/space";
+import { MutableSpaceData, parseSpaceData } from "../state/space";
 import { GameMemory } from "./game_memory";
 
 export const TURN_ORDER = new Key("turnOrder", {
@@ -38,7 +38,7 @@ export const GRID_VERSION = new Key("gridVersion", { parse: z.number().parse });
 export const GRID = new MapKey<Coordinates, MutableSpaceData>(
   "grid",
   CoordinatesZod.parse,
-  MutableSpaceData.parse,
+  parseSpaceData,
 );
 
 export const INTER_CITY_CONNECTIONS = new Key("interCityConnections", {
@@ -89,19 +89,59 @@ export const injectCurrentPlayer = compose(
     players().find((player) => player.color === currentPlayer())!,
 );
 
-export const injectGrid = compose(
-  () => ({
-    game: inject(GameMemory),
-    grid: injectState(GRID),
-    connections: injectState(INTER_CITY_CONNECTIONS),
-  }),
-  ({ grid, game, connections }, previousGrid?: Grid) => {
-    if (previousGrid) {
-      return previousGrid.merge(grid(), connections() ?? []);
+const NO_CONNECTIONS: InterCityConnection[] = [];
+
+/**
+ * The Grid for the current state, rebuilt only when the underlying state changes.
+ *
+ * Deliberately not written with `compose`, which re-runs its transform on every
+ * call. Rebuilding here means `Grid.merge`, which deep-compares every space's data
+ * against the space already built -- affordable once per change, but this getter is
+ * called many times per action (every neighbor lookup during route finding goes
+ * through it), and re-merging on each call dominated the engine: it was ~80% of a
+ * recorded playthrough replay, and the same cost is paid serving a real move.
+ *
+ * Both inputs come from the StateStore, which replaces a value's reference on
+ * write and never mutates in place, so reference equality is a sound test for
+ * "unchanged" -- the same assumption `composeState` already makes. When the state
+ * has changed we still merge into the previous Grid rather than rebuilding from
+ * scratch, so untouched spaces keep their identity.
+ */
+export function injectGrid(): () => Grid {
+  const game = inject(GameMemory);
+  const grid = injectState(GRID);
+  const connections = injectState(INTER_CITY_CONNECTIONS);
+
+  let memoized:
+    | {
+        gridData: ReturnType<typeof grid>;
+        connectionsData: ReturnType<typeof connections>;
+        value: Grid;
+      }
+    | undefined;
+
+  return () => {
+    const gridData = grid();
+    const connectionsData = connections();
+    if (
+      memoized != null &&
+      memoized.gridData === gridData &&
+      memoized.connectionsData === connectionsData
+    ) {
+      return memoized.value;
     }
-    const settings = MapRegistry.singleton.get(game.getGame().gameKey);
-    return Grid.fromData(settings, grid(), connections() ?? []);
-  },
-);
+
+    const value =
+      memoized != null
+        ? memoized.value.merge(gridData, connectionsData ?? NO_CONNECTIONS)
+        : Grid.fromData(
+            MapRegistry.singleton.get(game.getGame().gameKey),
+            gridData,
+            connectionsData ?? NO_CONNECTIONS,
+          );
+    memoized = { gridData, connectionsData, value };
+    return value;
+  };
+}
 
 export const TEST_ONLY_PLAYERS = PLAYERS;

--- a/src/engine/state/space.ts
+++ b/src/engine/state/space.ts
@@ -56,3 +56,22 @@ export type LandData = Immutable<MutableLandData>;
 export const MutableSpaceData = z.union([MutableCityData, MutableLandData]);
 export type MutableSpaceData = z.infer<typeof MutableSpaceData>;
 export type SpaceData = Immutable<MutableSpaceData>;
+
+/**
+ * Parses one space, dispatching on `type` instead of trying both members.
+ *
+ * `MutableSpaceData.parse` tries city first and, for the land spaces that make up
+ * most of a grid, builds and discards a ZodError before falling through -- which
+ * made error construction the single largest cost of parsing a grid. Dispatching
+ * skips that; a malformed space now reports against the shape it claims to be,
+ * rather than as a union of two failures.
+ *
+ * Not expressed as `z.discriminatedUnion`, which requires a literal or enum
+ * discriminator: MutableLandData's is `SpaceTypeZod.refine(isLandType)`.
+ */
+export function parseSpaceData(value: unknown): MutableSpaceData {
+  const type = (value as { type?: unknown } | null | undefined)?.type;
+  return type === SpaceType.CITY
+    ? MutableCityData.parse(value)
+    : MutableLandData.parse(value);
+}

--- a/src/utils/deep_equals.ts
+++ b/src/utils/deep_equals.ts
@@ -8,7 +8,6 @@ export function deepEquals<T>(
   t2: NoInfer<T>,
   path: string[] = [],
 ): unknown {
-  const pathStr = path.join(" -> ");
   if (isPrimitive(t1)) {
     return t1 === t2;
   } else if (t1 == null) {
@@ -46,8 +45,37 @@ export function deepEquals<T>(
   } else if (t1 instanceof Coordinates) {
     return t1 === t2;
   } else {
-    assert(typeof t1 === "object", `Expected object, found ${t1}: ` + pathStr);
-    assert(typeof t2 === "object", `Expected object, found ${t2}: ` + pathStr);
-    return deepEquals(new Map(Object.entries(t1)), new Map(Object.entries(t2)));
+    // Guarded so that neither the path string nor the interpolation of the values
+    // is built on the passing path -- this branch runs for every object compared.
+    if (typeof t1 !== "object" || typeof t2 !== "object") {
+      const pathStr = path.join(" -> ");
+      assert(
+        typeof t1 === "object",
+        `Expected object, found ${t1}: ` + pathStr,
+      );
+      assert(
+        typeof t2 === "object",
+        `Expected object, found ${t2}: ` + pathStr,
+      );
+    }
+    // Compares keys directly rather than routing through the Map branch above.
+    // That path looked up each key with a linear `find` over the other object's
+    // keys, making an object comparison quadratic in its field count.
+    const keys1 = Object.keys(t1 as object);
+    const o2 = t2 as Record<string, unknown>;
+    if (keys1.length !== Object.keys(o2).length) return false;
+    for (const key of keys1) {
+      if (!(key in o2)) return false;
+      if (
+        !deepEquals(
+          (t1 as Record<string, unknown>)[key],
+          o2[key],
+          path.concat(key),
+        )
+      ) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -86,9 +86,12 @@ export function removeKeys<T, R extends keyof T>(
   return result as Omit<T, R>;
 }
 
+// Hoisted: isPrimitive is called on every value deepEquals walks, and rebuilding
+// this set per call cost ~15% of a playthrough replay.
+const PRIMITIVE_TYPES = new Set(["boolean", "number", "string"]);
+
 export function isPrimitive(value: unknown): value is Primitive {
-  const primitives = new Set(["boolean", "number", "string"]);
-  return primitives.has(typeof value);
+  return PRIMITIVE_TYPES.has(typeof value);
 }
 
 export function partition<R, T>(arr: R[], fn: (r: R) => T): Map<T, R[]> {


### PR DESCRIPTION
The recorded playthrough suite took about ten minutes in CI, nearly all of it in one file: `central-new-england`, whose build rule re-checks for duplicate routes after every build and so walks the board repeatedly.

Profiling it (`--cpu-prof`) showed the cost was not that rule, the referee, or snapshotting — **reading the grid rebuilt it**. `injectGrid` was written with `compose`, which, unlike `composeState` directly below it, re-runs its transform on every call:

```ts
export function compose<T, R>(injectFn: () => T, runFn: (t: T, previous?: R) => R) {
  return () => { const injected = injectFn(); let previous: R | undefined;
    return () => { previous = runFn(injected, previous); return previous; }; };
}
```

So every `this.grid()` re-ran `Grid.merge`, deep-comparing every space's data against the space already built — and `grid()` is called constantly, since every neighbor lookup during route finding goes through it. `deepEquals` was **77% of the entire replay**, all of it entering from `Grid.merge`.

`injectGrid` now memoizes on the identity of the `GRID` and `INTER_CITY_CONNECTIONS` state values. That is sound because `StateStore.get` returns `container.state.value`, a reference only replaced on write and never mutated in place — the same assumption `composeState` already makes. When the state has genuinely changed we still merge into the previous `Grid`, so untouched spaces keep their identity.

Re-profiling after each fix surfaced three smaller costs on the same path:

- **`isPrimitive` built a `Set` on every call** (`utils/functions.ts`), and it is the first thing `deepEquals` does for every value it walks — 14.7% of runtime. Hoisted to a module constant.
- **`deepEquals` joined its `path` into a string at the top of every recursive call** though only two assertion messages use it, and compared plain objects by converting them to `Map`s — whose key lookup is a linear `find` with a deep compare per key, making an object comparison quadratic in its field count. It now compares keys directly and builds the message only on failure.
- **Every land space — most of a grid — built and discarded a full `ZodError` before parsing**, because `MutableSpaceData` is a `z.union` with the city shape first. After the fixes above this was 37% of what remained. `parseSpaceData` dispatches on `type` instead. Deliberately not `z.discriminatedUnion`, which requires a literal or enum discriminator; land's is `SpaceTypeZod.refine(isLandType)`.

## Results

| | before | after |
|---|---|---|
| playthrough suite (wall) | 274s | **27.9s** |
| playthrough suite (CPU) | 1206s | 180s |
| `central-new-england` alone | 86.2s | **2.79s** (31×) |

All 54 recordings still replay to **byte-identical transcripts**, which is what gives confidence none of this changed behaviour. All 1292 unit tests pass; lint and format clean.

## Note

This is engine code, not test code. A build action on a dense map was re-merging the grid per neighbor lookup while serving a **real** move, too — the test suite only made it visible.

I also found a pre-existing bug in `deepEquals`'s `Set` branch while in here, but deliberately left it out of this change since fixing it alters what compares equal; it's coming as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
